### PR TITLE
File class serialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,20 +8,68 @@
     <artifactId>variation-commons</artifactId>
     <version>0.1</version>
 
-    <build>
-        <sourceDirectory>src/main/java</sourceDirectory>
-        <testSourceDirectory>src/test/java</testSourceDirectory>
-    </build>
+    <properties>
+        <java.version>1.7</java.version>
+        <spring.boot.version>1.2.6.RELEASE</spring.boot.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+           <dependency>
+               <!-- Import dependency management from Spring Boot -->
+               <groupId>org.springframework.boot</groupId>
+               <artifactId>spring-boot-dependencies</artifactId>
+               <version>${spring.boot.version}</version>
+               <type>pom</type>
+               <scope>import</scope>
+           </dependency>
+       </dependencies>
+    </dependencyManagement>
+   
     <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+        </dependency>
+        
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>1.3</version>
         </dependency>
     </dependencies>
+    
+    <build>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <testSourceDirectory>src/test/java</testSourceDirectory>
+       
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    
 </project>

--- a/src/main/java/embl/ebi/variation/commons/models/metadata/File.java
+++ b/src/main/java/embl/ebi/variation/commons/models/metadata/File.java
@@ -18,16 +18,35 @@ package embl.ebi.variation.commons.models.metadata;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.persistence.Entity;
+import javax.persistence.Index;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+
+import org.springframework.data.jpa.domain.AbstractPersistable;
+
 /**
  * Created by parce on 02/10/15.
  */
-public class File {
+@Entity
+@Table(indexes = {@Index(name = "file_unique", columnList = "name,type,md5", unique = true)})
+public class File extends AbstractPersistable<Long> {
+
+    private static final long serialVersionUID = 4602079283068239196L;
 
     private String name;
     private File.Type type;
     private String md5;
-    private Set<FileGenerator> fileGenerators;
-    private Set<Sample> samples;
+    @Transient private Set<FileGenerator> fileGenerators;
+    @Transient private Set<Sample> samples;
+
+    public File() {
+        this(null, File.Type.OTHER, null);
+    }
+
+    public File(Long id) {
+        this.setId(id);
+    }
 
     public File(String name, File.Type type, String md5) {
         this(name, type, md5, new HashSet<FileGenerator>(), new HashSet<Sample>());
@@ -104,7 +123,7 @@ public class File {
             return false;
         } else {
             File otherFile = (File) object;
-            return (otherFile.getName().equals(name) && otherFile.getType().equals(type) && otherFile.getMd5().equals(md5));
+            return otherFile.getName().equals(name) && otherFile.getType().equals(type) && otherFile.getMd5().equals(md5);
         }
     }
 
@@ -119,9 +138,9 @@ public class File {
         hashCode = 31 * hashCode + c;
         return hashCode;
     }
-    
+
     public enum Type {
-        
+
         VCF("vcf"),
         VCF_AGGREGATE("vcf_aggregate"),
         README("readme_file"),
@@ -133,7 +152,7 @@ public class File {
         GFF("gff"),
         FASTA("fasta"),
         OTHER("other");
-        
+
         private final String name;
 
         private Type(String s) {
@@ -147,6 +166,6 @@ public class File {
         @Override
         public String toString() {
             return this.name;
-        }   
+        }
     }
 }

--- a/src/main/java/embl/ebi/variation/commons/models/metadata/File.java
+++ b/src/main/java/embl/ebi/variation/commons/models/metadata/File.java
@@ -116,6 +116,11 @@ public class File extends AbstractPersistable<Long> {
     }
 
     @Override
+    public String toString() {
+        return "File{" + "name=" + name + ", type=" + type + ", md5=" + md5 + '}';
+    }
+
+    @Override
     public boolean equals(Object object) {
         if (object == this) {
             return true;

--- a/src/test/java/embl/ebi/variation/commons/models/metadata/DatabaseTestConfiguration.java
+++ b/src/test/java/embl/ebi/variation/commons/models/metadata/DatabaseTestConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package embl.ebi.variation.commons.models.metadata;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Oliver Gierke
+ * @see https://github.com/spring-projects/spring-data-examples
+ * @todo Is it possible to move it to the subpackage 'database'?
+ */
+@Configuration
+@EnableAutoConfiguration
+public class DatabaseTestConfiguration {
+}

--- a/src/test/java/embl/ebi/variation/commons/models/metadata/database/FileDatabaseTest.java
+++ b/src/test/java/embl/ebi/variation/commons/models/metadata/database/FileDatabaseTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2015 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package embl.ebi.variation.commons.models.metadata.database;
+
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import embl.ebi.variation.commons.models.metadata.DatabaseTestConfiguration;
+import embl.ebi.variation.commons.models.metadata.File;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@Transactional
+@ContextConfiguration(classes = DatabaseTestConfiguration.class)
+public class FileDatabaseTest {
+
+	@Autowired
+	FileRepository repository;
+
+	File file1, file2;
+
+	@Before
+	public void setUp() {
+		file1 = new File("file1.vcf", File.Type.VCF, "7s6efgwe78748");
+		file2 = new File("file2.vcf", File.Type.VCF, "7s6efgwe78748");
+	}
+
+	/**
+	 * After saving a file in the database, when only the mandatory fields are
+	 * set, their values must be the same before and after, and optional fields
+	 * must be empty.
+	 */
+	@Test
+	public void testSaveMandatoryFields() {
+		File savedFile = repository.save(file1);
+
+		assertNotNull(savedFile.getId());
+		assertEquals(file1.getName(), savedFile.getName());
+		assertEquals(file1.getType(), savedFile.getType());
+		assertEquals(file1.getMd5(), savedFile.getMd5());
+		assertThat(savedFile.getSamples(), empty());
+		assertThat(savedFile.getFileGenerators(), empty());
+	}
+
+	/**
+	 * Two different files are both inserted into the database.
+	 */
+	@Test
+	public void testNonDuplicated() {
+		repository.save(file1);
+		repository.save(file2);
+		assertEquals(2, repository.count());
+	}
+
+	/**
+	 * Inserting the same file twice creates only one entry in the database.
+	 */
+	@Test
+	public void testDuplicated() {
+		File savedFile1 = repository.save(file1);
+		File savedFile2 = repository.save(file1);
+		assertEquals(1, repository.count());
+		assertEquals(savedFile1, savedFile2);
+	}
+
+	/**
+	 * A file before and after insertion must be considered equal. Two different
+	 * files in the database can't be equal.
+	 */
+	@Test
+	public void testEquals() {
+		// Compare saved and unsaved entities
+		File savedFile1 = repository.save(file1);
+		assertEquals(file1, savedFile1);
+
+		File savedFile2 = repository.save(file2);
+		// Compare two saved entities
+		assertEquals(file2, savedFile2);
+		assertNotEquals(file1, savedFile2);
+		assertNotEquals(savedFile1, savedFile2);
+	}
+
+	/**
+	 * The hash code before and after insertion must be the same.
+	 */
+	@Test
+	public void testHashCode() {
+		File savedFile1 = repository.save(file1);
+		assertEquals(file1.hashCode(), savedFile1.hashCode());
+	}
+}

--- a/src/test/java/embl/ebi/variation/commons/models/metadata/database/FileRepository.java
+++ b/src/test/java/embl/ebi/variation/commons/models/metadata/database/FileRepository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package embl.ebi.variation.commons.models.metadata.database;
+
+import org.springframework.data.repository.CrudRepository;
+
+import embl.ebi.variation.commons.models.metadata.File;
+
+public interface FileRepository extends CrudRepository<File, Long> {
+	
+}

--- a/src/test/resources/META-INF/persistence.xml
+++ b/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.0"
+	xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+	
+	<persistence-unit name="jpa.metadata">
+		<class>embl.ebi.variation.commons.models.metadata.File</class>
+		<properties>
+			<property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect" />
+			<property name="hibernate.connection.url" value="jdbc:hsqldb:mem:spring" />
+			<property name="hibernate.connection.driver_class" value="org.hsqldb.jdbcDriver" />
+			<property name="hibernate.connection.username" value="sa" />
+			<property name="hibernate.connection.password" value="" />
+			<property name="hibernate.hbm2ddl.auto" value="create-drop" />
+		</properties>
+	</persistence-unit>
+</persistence>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d %5p %40.40c:%4L - %m%n</pattern>
+		</encoder>
+	</appender>
+
+	<logger name="org.springframework" level="info" />
+	<logger name="org.hibernate" level="info" />
+	
+	<root level="error">
+		<appender-ref ref="console" />
+	</root>
+</configuration>


### PR DESCRIPTION
File class annotated for database serialization using Spring Data JPA. The attributes "fileGenerators" and "samples" are flagged as transient because they haven't been annotated yet.

To avoid any conflicts due to File.setXXX methods raising NullPointerException, the empty constructor now assigns the mandatory attributes values directly.

The dependencies in the POM file have been merged and some of them removed because they were provided by others such as spring-boot-starter-data-jpa, spring-boot-starter-test and gs-collections.