### PR TITLE
Spring Boot upgrade to version 1.3.7 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,30 +8,17 @@
     <artifactId>variation-commons</artifactId>
     <version>0.1</version>
 
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>1.3.7.RELEASE</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    
     <properties>
         <java.version>1.8</java.version>
-        <spring.boot.version>1.2.6.RELEASE</spring.boot.version>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-           <dependency>
-               <!-- Import dependency management from Spring Boot -->
-               <groupId>org.springframework.boot</groupId>
-               <artifactId>spring-boot-dependencies</artifactId>
-               <version>${spring.boot.version}</version>
-               <type>pom</type>
-               <scope>import</scope>
-               <exclusions>
-                   <exclusion>
-                        <groupId>commons-validator</groupId>
-                        <artifactId>commons-validator</artifactId>
-                   </exclusion>
-               </exclusions>
-           </dependency>
-       </dependencies>
-    </dependencyManagement>
-   
+    
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -83,7 +70,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>


### PR DESCRIPTION
Spring Boot upgraded from version 1.2.6 to 1.3.7 to match the one used by the EVA pipeline.
