### PR TITLE
EVA-612 Mongo driver version 2 to 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,11 +43,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
-            <version>2.14.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
         </dependency>
@@ -72,6 +67,7 @@
             <artifactId>biodata-models</artifactId>
             <version>${biodata.version}</version>
         </dependency>
+
 
     </dependencies>
     

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <spring.boot.version>1.2.6.RELEASE</spring.boot.version>
-        <biodata.version>0.4.5</biodata.version>
+        <spring.boot.version>1.4.2.RELEASE</spring.boot.version>
     </properties>
 
     <dependencyManagement>
@@ -65,7 +64,7 @@
         <dependency>
             <groupId>org.opencb.biodata</groupId>
             <artifactId>biodata-models</artifactId>
-            <version>${biodata.version}</version>
+            <version>0.4.5</version>
         </dependency>
 
 


### PR DESCRIPTION
- Mongo driver dependency exclusion from opencga (opencga dependency can be removed completely in sep branch)
- Removed mongo 2 driver dependency