### PR TITLE
OpenCGA dependency upgraded to v0.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
   - oraclejdk8
 
 env:
-  - OPENCGA_HOME=$TRAVIS_BUILD_DIR/opencga/opencga-app/build MONGODB_VERSION=3.0.4
+  - OPENCGA_HOME=$TRAVIS_BUILD_DIR/opencga/opencga-app/build
 
 
 before_install:

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env sh
 
-git clone -b hotfix/0.5 https://github.com/opencb/opencga.git
-cd opencga
-mvn install -DskipTests
+git clone -b hotfix/0.4 https://github.com/ebivariation/biodata.git
+git clone -b hotfix/0.5 https://github.com/ebivariation/opencga.git
+
+cd biodata && mvn install
+cd ..
+cd opencga && mvn install -DskipTests
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.opencb.opencga</groupId>
             <artifactId>opencga-storage-mongodb</artifactId>
-            <version>0.5.2</version>
+            <version>0.5.3</version>
         </dependency>
 
 


### PR DESCRIPTION
And Biodata 0.4.6, which now has to be downloaded from the Git repository because it's not available in Maven Central.