### PR TITLE
EVA-742 Altered DBObjectToSamplesConverter for fixing missing samplesData from mongo repository

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToSamplesConverter.java
+++ b/src/main/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToSamplesConverter.java
@@ -33,20 +33,18 @@ public class DBObjectToSamplesConverter implements Converter<DBObject, VariantSo
 
     @Override
     public VariantSourceEntry convert(DBObject object) {
-        
         BasicDBObject mongoGenotypes = (BasicDBObject) object.get(SAMPLES_FIELD);
 
         VariantSourceEntry fileWithSamples = new VariantSourceEntry(object.get(FILEID_FIELD).toString(), 
                 object.get(STUDYID_FIELD).toString());
 
         // Add the samples to the file
-        for (Object gtToIndexesObj: mongoGenotypes.entrySet()) {
-            Map.Entry<String, Object> gtToIndexes = (Map.Entry) gtToIndexesObj;
+        for (Map.Entry<String, Object> gtToIndexes: mongoGenotypes.entrySet()) {
             if (gtToIndexes.getKey().equals("def")) {
                 fileWithSamples = addGenotypeToVariantSourceEntry(fileWithSamples, "def",
                                                                   (String) gtToIndexes.getValue());
             } else {
-                String gtString = (String) gtToIndexes.getKey();
+                String gtString = gtToIndexes.getKey();
                 List<Integer> indexes = (List<Integer>) gtToIndexes.getValue();
                 for (Integer index : indexes) {
                     fileWithSamples = addGenotypeToVariantSourceEntry(fileWithSamples, Integer.toString(index),

--- a/src/main/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToSamplesConverter.java
+++ b/src/main/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToSamplesConverter.java
@@ -43,20 +43,26 @@ public class DBObjectToSamplesConverter implements Converter<DBObject, VariantSo
         for (Object gtToIndexesObj: mongoGenotypes.entrySet()) {
             Map.Entry<String, Object> gtToIndexes = (Map.Entry) gtToIndexesObj;
             if (gtToIndexes.getKey().equals("def")) {
-                Map<String, String> sampleData = new HashMap<>(1);
-                sampleData.put("GT", (String) gtToIndexes.getValue());
-                fileWithSamples.addSampleData("def", sampleData);
+                fileWithSamples = addGenotypeToVariantSourceEntry(fileWithSamples, "def",
+                                                                  (String) gtToIndexes.getValue());
             } else {
                 String gtString = (String) gtToIndexes.getKey();
                 List<Integer> indexes = (List<Integer>) gtToIndexes.getValue();
                 for (Integer index : indexes) {
-                    Map<String, String> sampleData = new HashMap<>(1);
-                    sampleData.put("GT", gtString);
-                    fileWithSamples.addSampleData(Integer.toString(index), sampleData);
+                    fileWithSamples = addGenotypeToVariantSourceEntry(fileWithSamples, Integer.toString(index),
+                                                                      gtString);
                 }
             }
         }
         
         return fileWithSamples;
+    }
+
+    private VariantSourceEntry addGenotypeToVariantSourceEntry(VariantSourceEntry file, String index,
+                                                               String gtString) {
+        Map<String, String> sampleData = new HashMap<>(1);
+        sampleData.put("GT", gtString);
+        file.addSampleData(index, sampleData);
+        return file;
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToSamplesConverter.java
+++ b/src/main/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToSamplesConverter.java
@@ -31,61 +31,13 @@ import static uk.ac.ebi.eva.commons.models.converters.data.DBObjectToVariantSour
 
 public class DBObjectToSamplesConverter implements Converter<DBObject, VariantSourceEntry> {
 
-//    private boolean compressSamples;
-//    private List<String> samples;
-    private Map<String, Integer> sampleIds;
-    private Map<Integer, String> idSamples;
-    private boolean compressDefaultGenotype;
-
-    /**
-     * Create a converter from a Map of samples to DBObject entities.
-     * 
-     * @param compressDefaultGenotype Whether to compress samples default genotype or not
-     */
-    public DBObjectToSamplesConverter(boolean compressDefaultGenotype) {
-        this.idSamples = null;
-        this.sampleIds = null;
-        this.compressDefaultGenotype = compressDefaultGenotype;
-    }
-
-    /**
-     * Create a converter from DBObject to a Map of samples, providing the list 
-     * of sample names.
-     * 
-     * @param samples The list of samples, if any
-     */
-    public DBObjectToSamplesConverter(List<String> samples) {
-        this(true);
-        setSamples(samples);
-    }
-
-    /**
-     * Create a converter from DBObject to a Map of samples, providing a map
-     * of sample names to the corresponding sample id.
-     *
-     * @param sampleIds Map of samples to sampleId
-     */
-    public DBObjectToSamplesConverter(boolean compressDefaultGenotype, Map<String, Integer> sampleIds) {
-        this(compressDefaultGenotype);
-        setSampleIds(sampleIds);
-    }
-
-
     @Override
     public VariantSourceEntry convert(DBObject object) {
         
-//        if (sampleIds == null || sampleIds.isEmpty()) {
-//            return new VariantSourceEntry(object.get(FILEID_FIELD).toString(), object.get(STUDYID_FIELD).toString());
-//        }
-        
         BasicDBObject mongoGenotypes = (BasicDBObject) object.get(SAMPLES_FIELD);
-//        int numSamples = idSamples.size();
-        
-        // Temporary file, just to store the samples
+
         VariantSourceEntry fileWithSamples = new VariantSourceEntry(object.get(FILEID_FIELD).toString(), 
                 object.get(STUDYID_FIELD).toString());
-
-
 
         // Add the samples to the file
         for (Object gtToIndexesObj: mongoGenotypes.entrySet()) {
@@ -104,59 +56,7 @@ public class DBObjectToSamplesConverter implements Converter<DBObject, VariantSo
                 }
             }
         }
-
-//        for (Map.Entry<String, Integer> entry : mongoGenotypes.values()) {
-//            Map<String, String> sampleData = new HashMap<>(1);  //size == 1, only will contain GT field
-//            fileWithSamples.addSampleData(entry.getKey(), sampleData);
-//        }
-//
-//        // An array of genotypes is initialized with the most common one
-//        String mostCommonGtString = mongoGenotypes.getString("def");
-//        if(mostCommonGtString != null) {
-//            for (Map.Entry<String, Map<String, String>> entry : fileWithSamples.getSamplesData().entrySet()) {
-//                entry.getValue().put("GT", mostCommonGtString);
-//            }
-//        }
-//
-//        // Loop through the non-most commmon genotypes, and set their value
-//        // in the position specified in the array, such as:
-//        // "0|1" : [ 41, 311, 342, 358, 881, 898, 903 ]
-//        // genotypes[41], genotypes[311], etc, will be set to "0|1"
-//        for (Map.Entry<String, Object> dbo : mongoGenotypes.entrySet()) {
-//            if (!dbo.getKey().equals("def")) {
-//                String genotype = dbo.getKey().replace("-1", ".");
-//                for (Integer sampleId : (List<Integer>) dbo.getValue()) {
-//                    if (idSamples.containsKey(sampleId)) {
-//                        fileWithSamples.getSamplesData().get(idSamples.get(sampleId)).put("GT", genotype);
-//                    }
-//                }
-//            }
-//        }
-
-
         
         return fileWithSamples;
-    }
-
-    public void setSamples(List<String> samples) {
-        int i = 0;
-        assert samples != null;
-        int size = samples.size();
-        sampleIds = new HashMap<>(size);
-        idSamples = new HashMap<>(size);
-        for (String sample : samples) {
-            sampleIds.put(sample, i);
-            idSamples.put(i, sample);
-            i++;
-        }
-    }
-
-    public void setSampleIds(Map<String, Integer> sampleIds) {
-        this.sampleIds = new HashMap<String, Integer>(sampleIds);
-        this.idSamples = new HashMap<>(this.sampleIds.size());
-        for (Map.Entry<String, Integer> entry : this.sampleIds.entrySet()) {
-            idSamples.put(entry.getValue(), entry.getKey());
-        }
-        assert sampleIds.size() == idSamples.size();
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToSamplesConverter.java
+++ b/src/main/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToSamplesConverter.java
@@ -40,11 +40,11 @@ public class DBObjectToSamplesConverter implements Converter<DBObject, VariantSo
 
         // Add the samples to the file
         for (Map.Entry<String, Object> gtToIndexes: mongoGenotypes.entrySet()) {
-            if (gtToIndexes.getKey().equals("def")) {
+            String gtString = gtToIndexes.getKey();
+            if (gtString.equals("def")) {
                 fileWithSamples = addGenotypeToVariantSourceEntry(fileWithSamples, "def",
                                                                   (String) gtToIndexes.getValue());
             } else {
-                String gtString = gtToIndexes.getKey();
                 List<Integer> indexes = (List<Integer>) gtToIndexes.getValue();
                 for (Integer index : indexes) {
                     fileWithSamples = addGenotypeToVariantSourceEntry(fileWithSamples, Integer.toString(index),

--- a/src/main/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToVariantEntityConverter.java
+++ b/src/main/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToVariantEntityConverter.java
@@ -29,7 +29,7 @@ public class DBObjectToVariantEntityConverter implements Converter<DBObject, Var
     public VariantEntity convert(DBObject dbObject) {
         DBObjectToVariantConverter converter =
                 new DBObjectToVariantConverter(
-                        new DBObjectToVariantSourceEntryConverter(new DBObjectToSamplesConverter(false)),
+                        new DBObjectToVariantSourceEntryConverter(new DBObjectToSamplesConverter()),
                         new DBObjectToVariantStatsConverter()
                 );
         return new VariantEntity(converter.convert(dbObject));

--- a/src/main/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToVariantEntityConverter.java
+++ b/src/main/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToVariantEntityConverter.java
@@ -29,7 +29,7 @@ public class DBObjectToVariantEntityConverter implements Converter<DBObject, Var
     public VariantEntity convert(DBObject dbObject) {
         DBObjectToVariantConverter converter =
                 new DBObjectToVariantConverter(
-                        new DBObjectToVariantSourceEntryConverter(),
+                        new DBObjectToVariantSourceEntryConverter(new DBObjectToSamplesConverter(false)),
                         new DBObjectToVariantStatsConverter()
                 );
         return new VariantEntity(converter.convert(dbObject));

--- a/src/test/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToVariantConverterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToVariantConverterTest.java
@@ -106,7 +106,7 @@ public class DBObjectToVariantConverterTest {
         sampleNames.add("NA002");
         DBObjectToVariantConverter converter = new DBObjectToVariantConverter(
                 new DBObjectToVariantSourceEntryConverter(
-                        new DBObjectToSamplesConverter(sampleNames)),
+                        new DBObjectToSamplesConverter()),
                 new DBObjectToVariantStatsConverter());
         Variant converted = converter.convert(mongoVariant);
         assertEquals(variant, converted);

--- a/src/test/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToVariantSourceEntryConverterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToVariantSourceEntryConverterTest.java
@@ -90,7 +90,7 @@ public class DBObjectToVariantSourceEntryConverterTest {
     }
 
     @Test
-    public void testConvertToDataTypeWithoutStatsWithSampleIds() {
+    public void testConvertToDataModelTypeWithoutStats() {
         DBObjectToVariantSourceEntryConverter converter;
         VariantSourceEntry convertedFile;
 

--- a/src/test/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToVariantSourceEntryConverterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToVariantSourceEntryConverterTest.java
@@ -92,9 +92,7 @@ public class DBObjectToVariantSourceEntryConverterTest {
     @Test
     public void testConvertToDataTypeWithoutStatsWithSampleIds() {
         DBObjectToVariantSourceEntryConverter converter;
-        DBObject convertedMongo;
         VariantSourceEntry convertedFile;
-
 
         // Test with no stats converter provided
         converter = new DBObjectToVariantSourceEntryConverter(

--- a/src/test/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToVariantSourceEntryConverterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/commons/models/converters/data/DBObjectToVariantSourceEntryConverterTest.java
@@ -48,15 +48,15 @@ public class DBObjectToVariantSourceEntryConverterTest {
         file.addAttribute("MAX.PROC", "2");
         file.setFormat("GT");
 
-        Map<String, String> na001 = new HashMap<>();
-        na001.put("GT", "0/0");
-        file.addSampleData("NA001", na001);
+        Map<String, String> def = new HashMap<>();
+        def.put("GT", "0/0");
+        file.addSampleData("def", def);
         Map<String, String> na002 = new HashMap<>();
         na002.put("GT", "0/1");
-        file.addSampleData("NA002", na002);
+        file.addSampleData("25", na002);
         Map<String, String> na003 = new HashMap<>();
         na003.put("GT", "1/1");
-        file.addSampleData("NA003", na003);
+        file.addSampleData("35", na003);
 
         // MongoDB object
         mongoFile = new BasicDBObject(DBObjectToVariantSourceEntryConverter.FILEID_FIELD, file.getFileId())
@@ -90,24 +90,6 @@ public class DBObjectToVariantSourceEntryConverterTest {
     }
 
     @Test
-    public void testConvertToDataModelTypeWithoutStats() {
-        file.getSamplesData().clear(); // TODO Samples can't be tested easily, needs a running Mongo instance
-        List<String> sampleNames = new ArrayList<String>();
-
-        // Test with no stats converter provided
-        DBObjectToVariantSourceEntryConverter converter = new DBObjectToVariantSourceEntryConverter(
-                new DBObjectToSamplesConverter(sampleNames));
-        VariantSourceEntry converted = converter.convert(mongoFile);
-        assertEquals(file, converted);
-
-        // Test with a stats converter provided but no stats object
-        converter = new DBObjectToVariantSourceEntryConverter(
-                new DBObjectToSamplesConverter(sampleNames));
-        converted = converter.convert(mongoFile);
-        assertEquals(file, converted);
-    }
-
-    @Test
     public void testConvertToDataTypeWithoutStatsWithSampleIds() {
         DBObjectToVariantSourceEntryConverter converter;
         DBObject convertedMongo;
@@ -116,14 +98,14 @@ public class DBObjectToVariantSourceEntryConverterTest {
 
         // Test with no stats converter provided
         converter = new DBObjectToVariantSourceEntryConverter(
-                new DBObjectToSamplesConverter(true, sampleIds)
+                new DBObjectToSamplesConverter()
         );
         convertedFile = converter.convert(mongoFileWithIds);
         assertEquals(file, convertedFile);
 
         // Test with a stats converter provided but no stats object
         converter = new DBObjectToVariantSourceEntryConverter(
-                new DBObjectToSamplesConverter(true, sampleIds)
+                new DBObjectToSamplesConverter()
         );
         convertedFile = converter.convert(mongoFileWithIds);
         assertEquals(file, convertedFile);


### PR DESCRIPTION
Altered DBObjectToSamplesConverter to map sample indexes in a file to their genotype, regardless of their sample name.
This is part of the solution to fixing the problem where VariantEntityRepositoryImpl in eva-ws was returning VariantEntities without samplesData.