### PR TITLE
EVA-770 Populate HGVS and OpenCGA dependency update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.ac.ebi.eva</groupId>
     <artifactId>variation-commons</artifactId>
-    <version>0.2</version>
+    <version>0.2.1</version>
 
     <properties>
         <java.version>1.8</java.version>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
             <artifactId>opencga-storage-mongodb</artifactId>
-            <version>0.5.4</version>
+            <version>0.5.5</version>
         </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <properties>
         <java.version>1.8</java.version>
         <spring.boot.version>1.4.2.RELEASE</spring.boot.version>
+        <opencga.version>0.5.5</opencga.version>
     </properties>
 
     <dependencyManagement>
@@ -81,10 +82,38 @@
         <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
             <artifactId>opencga-storage-mongodb</artifactId>
-            <version>0.5.5</version>
+            <version>${opencga.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jersey.contribs</groupId>
+                    <artifactId>jersey-multipart</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mongodb</groupId>
+                    <artifactId>mongo-java-driver</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-
-
     </dependencies>
     
     <build>

--- a/src/main/java/uk/ac/ebi/eva/commons/models/metadata/VariantEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/commons/models/metadata/VariantEntity.java
@@ -34,6 +34,7 @@ public class VariantEntity extends Variant {
         setAlternate(variant.getAlternate());
         setReference(variant.getReference());
         setType(variant.getType());
+        setHgvs(variant.getHgvs());
         setAnnotation(variant.getAnnotation());
         setSourceEntries(variant.getSourceEntries());
     }


### PR DESCRIPTION
* Using OpenCGA version 0.5.5 including bugfix from [opencga#6](https://github.com/EBIvariation/opencga/pull/6), which needs to be pushed to Artifactory in order for this build to pass
* Version bumped to 0.2.1
* Populates correctly the HGVS in a `VariantEntity` built from a `Variant`
* OpenCGA dependency managed in variation-commons for consistency across all EVA repositories