### PR TITLE
EVA-837 Support databases with no VEP annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.ac.ebi.eva</groupId>
     <artifactId>variation-commons</artifactId>
-    <version>0.4</version>
+    <version>0.4.1</version>
 
     <properties>
         <java.version>1.8</java.version>

--- a/src/main/java/uk/ac/ebi/eva/commons/mongodb/services/VariantWithSamplesAndAnnotationsService.java
+++ b/src/main/java/uk/ac/ebi/eva/commons/mongodb/services/VariantWithSamplesAndAnnotationsService.java
@@ -122,7 +122,9 @@ public class VariantWithSamplesAndAnnotationsService {
         Table<String, String, Map<String, VariantStatistics>> variantStatisticsMongosTable
                 = variantStatsMongoToTable(variantMongo.getVariantStatsMongo(), variantMongo);
         variant.addSourceEntries(convert(variantMongo.getSourceEntries(), sampleNames, variantStatisticsMongosTable));
-        variant.setAnnotation(new Annotation(annotation));
+        if (annotation != null) {
+            variant.setAnnotation(new Annotation(annotation));
+        }
         return variant;
     }
 

--- a/src/main/java/uk/ac/ebi/eva/commons/mongodb/services/VariantWithSamplesAndAnnotationsService.java
+++ b/src/main/java/uk/ac/ebi/eva/commons/mongodb/services/VariantWithSamplesAndAnnotationsService.java
@@ -83,19 +83,19 @@ public class VariantWithSamplesAndAnnotationsService {
             List<AnnotationMetadataMongo> annotationMetadataList = annotationMetadataRepository.findByDefaultVersionTrue();
             if (annotationMetadataList.size() > 0) {
                 annotationMetadata = annotationMetadataList.get(0);
-            } else {
-                throw new AnnotationMetadataNotFoundException();
             }
-        } else {
-            if (annotationMetadataRepository.findByCacheVersionAndVepVersion(annotationMetadata.getCacheVersion(),
-                                                                             annotationMetadata.getVepVersion()).size() == 0) {
-                throw new AnnotationMetadataNotFoundException(annotationMetadataRepository.findAllByOrderByCacheVersionDescVepVersionDesc(),
-                                                              annotationMetadata);
-            }
+        } else if (annotationMetadataRepository.findByCacheVersionAndVepVersion(annotationMetadata.getCacheVersion(),
+                                                                                annotationMetadata.getVepVersion())
+                                               .size() == 0) {
+            throw new AnnotationMetadataNotFoundException(annotationMetadataRepository.findAllByOrderByCacheVersionDescVepVersionDesc(),
+                                                          annotationMetadata);
         }
 
+
         Map<String, AnnotationMongo> indexedAnnotations =
-                annotationRepository.findAndIndexAnnotationsOfVariants(variantMongos, annotationMetadata);
+                (annotationMetadata != null) ?
+                        annotationRepository.findAndIndexAnnotationsOfVariants(variantMongos, annotationMetadata)
+                        : new HashMap<>();
 
         List<VariantWithSamplesAndAnnotation> variantsList =
                 variantMongos.stream().map(variant ->


### PR DESCRIPTION
Return variants from service without annotations if no default specified in annotation metadata collection or no annotation data at all.