### PR TITLE
EVA-971 Retain submitted identifiers in VCFs

### DIFF
--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/AbstractVariant.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/AbstractVariant.java
@@ -79,6 +79,13 @@ public abstract class AbstractVariant implements IVariant {
     private final Set<String> ids;
 
     /**
+     * Set of identifiers used for this genomic variation, according to dbsnp.
+     * @deprecated this field is temporal for the dbsnp import, use getIds or getMainId instead
+     */
+    @Deprecated
+    private final Set<String> dbsnpIds;
+
+    /**
      * Unique identifier following the HGVS nomenclature.
      */
     private final Map<String, Set<String>> hgvs;
@@ -91,6 +98,7 @@ public abstract class AbstractVariant implements IVariant {
         this.alternate = null;
         this.mainId = null;
         this.ids = new HashSet<>();
+        this.dbsnpIds = new HashSet<>();
         this.hgvs = new HashMap<>();
     }
 
@@ -110,6 +118,7 @@ public abstract class AbstractVariant implements IVariant {
         this.mainId = null;
 
         this.ids = new HashSet<>();
+        this.dbsnpIds = new HashSet<>();
         this.hgvs = new HashMap<>();
         if (getType() == VariantType.SNV) { // Generate HGVS code only for SNVs
             Set<String> hgvsCodes = new HashSet<>();
@@ -183,6 +192,19 @@ public abstract class AbstractVariant implements IVariant {
 
     public Set<String> getIds() {
         return Collections.unmodifiableSet(ids);
+    }
+
+    public void addDbsnpId(String id) {
+        this.dbsnpIds.add(id);
+    }
+
+    public void setDbsnpIds(Set<String> ids) {
+        this.dbsnpIds.clear();
+        this.dbsnpIds.addAll(ids);
+    }
+
+    public Set<String> getDbsnpIds() {
+        return Collections.unmodifiableSet(dbsnpIds);
     }
 
     public boolean addHgvs(String type, String value) {

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/AbstractVariant.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/AbstractVariant.java
@@ -80,7 +80,7 @@ public abstract class AbstractVariant implements IVariant {
 
     /**
      * Set of identifiers used for this genomic variation, according to dbsnp.
-     * @deprecated this field is temporal for the dbsnp import, use getIds or getMainId instead
+     * @deprecated this field is temporary for the dbsnp import, use getIds or getMainId instead
      */
     @Deprecated
     private final Set<String> dbsnpIds;

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/IVariant.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/IVariant.java
@@ -42,6 +42,10 @@ public interface IVariant {
 
     default String getMainId() { return null; }
 
+    /** @deprecated this field is temporal, use getIds or getMainId instead */
+    @Deprecated
+    Set<String> getDbsnpIds();
+
     Map<String, Set<String>> getHgvs();
 
     Collection<? extends IVariantSourceEntry> getSourceEntries();

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/IVariant.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/IVariant.java
@@ -42,7 +42,7 @@ public interface IVariant {
 
     default String getMainId() { return null; }
 
-    /** @deprecated this field is temporal, use getIds or getMainId instead */
+    /** @deprecated this field is temporary, use getIds or getMainId instead */
     @Deprecated
     Set<String> getDbsnpIds();
 

--- a/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/entities/VariantMongo.java
+++ b/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/entities/VariantMongo.java
@@ -70,6 +70,8 @@ public class VariantMongo {
 
     public final static String IDS_FIELD = "ids";
 
+    public final static String DBSNP_IDS_FIELD = "dbsnpIds";
+
     public final static String MAIN_ID_FIELD = "mainId";
 
     public final static String FILES_FIELD = "files";

--- a/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/entities/VariantMongo.java
+++ b/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/entities/VariantMongo.java
@@ -70,6 +70,8 @@ public class VariantMongo {
 
     public final static String IDS_FIELD = "ids";
 
+    public final static String MAIN_ID_FIELD = "mainId";
+
     public final static String FILES_FIELD = "files";
 
     public final static String STATISTICS_FIELD = "st";
@@ -109,6 +111,9 @@ public class VariantMongo {
     @Field(IDS_FIELD)
     private Set<String> ids;
 
+    @Field(MAIN_ID_FIELD)
+    private String mainId;
+
     @Field(FILES_FIELD)
     private Set<VariantSourceEntryMongo> variantSourceEntries;
 
@@ -127,6 +132,7 @@ public class VariantMongo {
                 -1,
                 -1,
                 -1,
+                null,
                 null,
                 null,
                 null,
@@ -155,6 +161,7 @@ public class VariantMongo {
                 generateAtField(variant.getChromosome(), variant.getStart()),
                 HgvsMongo.createHgvsMongo(variant.getHgvs()),
                 variant.getIds(),
+                variant.getMainId(),
                 VariantSourceEntryMongo.createSourceEntries(variant.getSourceEntries()),
                 null,
                 null
@@ -177,14 +184,15 @@ public class VariantMongo {
                 null,
                 null,
                 null,
+                null,
                 null
         );
     }
 
     public VariantMongo(String id, VariantType type, String chromosome, long start, long end, int length,
                         String reference, String alternate, VariantAtMongo at, Set<HgvsMongo> hgvs, Set<String> ids,
-                        Set<VariantSourceEntryMongo> variantSourceEntries, Set<VariantStatisticsMongo> variantStatsMongo,
-                        Set<AnnotationIndexMongo> indexedAnnotations) {
+                        String mainId, Set<VariantSourceEntryMongo> variantSourceEntries,
+                        Set<VariantStatisticsMongo> variantStatsMongo, Set<AnnotationIndexMongo> indexedAnnotations) {
         this.id = id;
         this.type = type;
         this.chromosome = chromosome;
@@ -202,6 +210,7 @@ public class VariantMongo {
         if (ids != null && !ids.isEmpty()) {
             this.ids.addAll(ids);
         }
+        this.mainId = mainId;
         this.variantSourceEntries = new HashSet<>();
         if (variantSourceEntries != null && !variantSourceEntries.isEmpty()) {
             this.variantSourceEntries.addAll(variantSourceEntries);

--- a/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/writers/VariantMongoWriter.java
+++ b/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/writers/VariantMongoWriter.java
@@ -39,6 +39,7 @@ import java.util.Map;
 
 import static uk.ac.ebi.eva.commons.mongodb.entities.VariantMongo.ANNOTATION_FIELD;
 import static uk.ac.ebi.eva.commons.mongodb.entities.VariantMongo.IDS_FIELD;
+import static uk.ac.ebi.eva.commons.mongodb.entities.VariantMongo.MAIN_ID_FIELD;
 import static uk.ac.ebi.eva.commons.mongodb.entities.subdocuments.AnnotationIndexMongo.SO_ACCESSION_FIELD;
 import static uk.ac.ebi.eva.commons.mongodb.entities.subdocuments.AnnotationIndexMongo.XREFS_FIELD;
 
@@ -103,19 +104,20 @@ public class VariantMongoWriter extends MongoItemWriter<IVariant> {
     protected void doWrite(List<? extends IVariant> variants) {
         BulkWriteOperation bulk = mongoOperations.getCollection(collection).initializeUnorderedBulkOperation();
         for (IVariant variant : variants) {
-            String id = VariantMongo.buildVariantId(variant.getChromosome(), variant.getStart(),
-                                                    variant.getReference(), variant.getAlternate());
-
-            // the chromosome and start appear just as shard keys, in an unsharded cluster they wouldn't be needed
-            BasicDBObject query = new BasicDBObject("_id", id)
-                    .append(VariantMongo.CHROMOSOME_FIELD, variant.getChromosome())
-                    .append(VariantMongo.START_FIELD, variant.getStart());
-
-            bulk.find(query).upsert().updateOne(generateUpdate(variant));
-
+            bulk.find(generateQuery(variant)).upsert().updateOne(generateUpdate(variant));
         }
 
         executeBulk(bulk, variants.size());
+    }
+
+    private BasicDBObject generateQuery(IVariant variant) {
+        String id = VariantMongo.buildVariantId(variant.getChromosome(), variant.getStart(),
+                                                variant.getReference(), variant.getAlternate());
+
+        // the chromosome and start appear just as shard keys, in an unsharded cluster they wouldn't be needed
+        return new BasicDBObject("_id", id)
+                .append(VariantMongo.CHROMOSOME_FIELD, variant.getChromosome())
+                .append(VariantMongo.START_FIELD, variant.getStart());
     }
 
     private void executeBulk(BulkWriteOperation bulk, int currentBulkSize) {
@@ -129,6 +131,31 @@ public class VariantMongoWriter extends MongoItemWriter<IVariant> {
         Assert.notNull(variant, "Variant should not be null. Please provide a valid Variant object");
         logger.trace("Convert variant {} into mongo object", variant);
 
+        BasicDBObject update = new BasicDBObject();
+
+        addOperatorAddToSet(variant, update);
+        addOperatorSetOnInsert(variant, update);
+        addOperatorSet(variant, update);
+
+        return update;
+    }
+
+    private void addOperatorSetOnInsert(IVariant variant, BasicDBObject update) {
+        update.append("$setOnInsert", convertVariant(variant));
+    }
+
+    private void addOperatorSet(IVariant variant, BasicDBObject update) {
+        BasicDBObject overwrite = new BasicDBObject();
+        if (variant.getMainId() != null) {
+            overwrite.put(MAIN_ID_FIELD, variant.getMainId());
+        }
+
+        if (!overwrite.isEmpty()) {
+            update.append("$set", overwrite);
+        }
+    }
+
+    private void addOperatorAddToSet(IVariant variant, BasicDBObject update) {
         BasicDBObject addToSet = new BasicDBObject();
 
         if (!variant.getSourceEntries().isEmpty()) {
@@ -146,13 +173,9 @@ public class VariantMongoWriter extends MongoItemWriter<IVariant> {
             addToSet.put(IDS_FIELD, new BasicDBObject("$each", variant.getIds()));
         }
 
-        BasicDBObject update = new BasicDBObject();
         if (!addToSet.isEmpty()) {
             update.put("$addToSet", addToSet);
         }
-        update.append("$setOnInsert", convertVariant(variant));
-
-        return update;
     }
 
     private IVariantSourceEntry getVariantSourceEntry(IVariant variant) {

--- a/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/writers/VariantMongoWriter.java
+++ b/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/writers/VariantMongoWriter.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 import static uk.ac.ebi.eva.commons.mongodb.entities.VariantMongo.ANNOTATION_FIELD;
+import static uk.ac.ebi.eva.commons.mongodb.entities.VariantMongo.DBSNP_IDS_FIELD;
 import static uk.ac.ebi.eva.commons.mongodb.entities.VariantMongo.IDS_FIELD;
 import static uk.ac.ebi.eva.commons.mongodb.entities.VariantMongo.MAIN_ID_FIELD;
 import static uk.ac.ebi.eva.commons.mongodb.entities.subdocuments.AnnotationIndexMongo.SO_ACCESSION_FIELD;
@@ -171,6 +172,10 @@ public class VariantMongoWriter extends MongoItemWriter<IVariant> {
 
         if (variant.getIds() != null && !variant.getIds().isEmpty()) {
             addToSet.put(IDS_FIELD, new BasicDBObject("$each", variant.getIds()));
+        }
+
+        if (variant.getIds() != null && !variant.getIds().isEmpty()) {
+            addToSet.put(DBSNP_IDS_FIELD, new BasicDBObject("$each", variant.getDbsnpIds()));
         }
 
         if (!addToSet.isEmpty()) {

--- a/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/writers/VariantMongoWriter.java
+++ b/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/writers/VariantMongoWriter.java
@@ -174,7 +174,7 @@ public class VariantMongoWriter extends MongoItemWriter<IVariant> {
             addToSet.put(IDS_FIELD, new BasicDBObject("$each", variant.getIds()));
         }
 
-        if (variant.getIds() != null && !variant.getIds().isEmpty()) {
+        if (variant.getDbsnpIds() != null && !variant.getDbsnpIds().isEmpty()) {
             addToSet.put(DBSNP_IDS_FIELD, new BasicDBObject("$each", variant.getDbsnpIds()));
         }
 

--- a/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/writers/VariantMongoWriter.java
+++ b/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/writers/VariantMongoWriter.java
@@ -170,11 +170,11 @@ public class VariantMongoWriter extends MongoItemWriter<IVariant> {
             }
         }
 
-        if (variant.getIds() != null && !variant.getIds().isEmpty()) {
+        if (!variant.getIds().isEmpty()) {
             addToSet.put(IDS_FIELD, new BasicDBObject("$each", variant.getIds()));
         }
 
-        if (variant.getDbsnpIds() != null && !variant.getDbsnpIds().isEmpty()) {
+        if (!variant.getDbsnpIds().isEmpty()) {
             addToSet.put(DBSNP_IDS_FIELD, new BasicDBObject("$each", variant.getDbsnpIds()));
         }
 

--- a/variation-commons-mongodb/src/test/java/uk/ac/ebi/eva/commons/mongodb/writers/VariantMongoWriterTest.java
+++ b/variation-commons-mongodb/src/test/java/uk/ac/ebi/eva/commons/mongodb/writers/VariantMongoWriterTest.java
@@ -56,6 +56,7 @@ import static uk.ac.ebi.eva.commons.mongodb.entities.VariantMongo.CHROMOSOME_FIE
 import static uk.ac.ebi.eva.commons.mongodb.entities.VariantMongo.END_FIELD;
 import static uk.ac.ebi.eva.commons.mongodb.entities.VariantMongo.FILES_FIELD;
 import static uk.ac.ebi.eva.commons.mongodb.entities.VariantMongo.IDS_FIELD;
+import static uk.ac.ebi.eva.commons.mongodb.entities.VariantMongo.MAIN_ID_FIELD;
 import static uk.ac.ebi.eva.commons.mongodb.entities.VariantMongo.REFERENCE_FIELD;
 import static uk.ac.ebi.eva.commons.mongodb.entities.VariantMongo.START_FIELD;
 import static uk.ac.ebi.eva.commons.mongodb.entities.VariantMongo.STATISTICS_FIELD;
@@ -206,8 +207,10 @@ public class VariantMongoWriterTest {
     @Test
     public void idsIfPresentShouldBeWrittenIntoTheVariant() throws Exception {
         Variant variant = buildVariantWithStats("12", 3, 4, "A", "T", "fileId", "studyId");
-        HashSet<String> ids = new HashSet<>(Arrays.asList("a", "b", "c"));
+        String mainId = "b";
+        HashSet<String> ids = new HashSet<>(Arrays.asList("a", mainId, "c"));
         variant.setIds(ids);
+        variant.setMainId(mainId);
 
         VariantMongoWriter variantMongoWriter = new VariantMongoWriter(collectionName, mongoOperations, false, true);
         variantMongoWriter.write(Collections.singletonList(variant));
@@ -220,6 +223,7 @@ public class VariantMongoWriterTest {
             assertTrue(dbIds.contains(id));
         }
         assertEquals(ids.size(), dbIds.size());
+        assertEquals(mainId, storedVariant.get(MAIN_ID_FIELD));
     }
 
     @Test
@@ -233,6 +237,7 @@ public class VariantMongoWriterTest {
         assertEquals(1, dbCollection.count());
         final DBObject storedVariant = dbCollection.findOne();
         assertNull(storedVariant.get(IDS_FIELD));
+        assertNull(storedVariant.get(MAIN_ID_FIELD));
     }
 
     @Test

--- a/variation-commons-mongodb/src/test/java/uk/ac/ebi/eva/commons/mongodb/writers/VariantMongoWriterTest.java
+++ b/variation-commons-mongodb/src/test/java/uk/ac/ebi/eva/commons/mongodb/writers/VariantMongoWriterTest.java
@@ -82,7 +82,7 @@ public class VariantMongoWriterTest {
 
     private static final HashSet<String> DBSNP_IDS = new HashSet<>(Arrays.asList("d", MAIN_ID, "e"));
 
-    private final String COLLECTION_NAME = "variants";
+    private static final String COLLECTION_NAME = "variants";
 
     @Autowired
     private MongoOperations mongoOperations;


### PR DESCRIPTION
- Complete support for mainId (we forgot the VariantMongoWriter)
- Add field dbsnpIds, which is meant for storing (temporarily) the new official ids. When we finish the import from dbsnp, we will delete the current field ids in mongo and will rename the dbsnpIds into ids, and then we can remove the dbsnpIds field from the java objects.  The ids will remain in the file.attrs.src.