### PR TITLE
EVA-1155 Exclude non variants refactor

### DIFF
--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -410,23 +410,14 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
     @Override
     protected void checkVariantInformation(Variant variant, String fileId, String studyId)
             throws NonVariantException, IncompleteInformationException {
+        super.checkVariantInformation(variant, fileId, studyId);
+
         VariantSourceEntry variantSourceEntry = variant.getSourceEntry(fileId, studyId);
-        if (!isVariant(variantSourceEntry)) {
-            throw new NonVariantException("The variant " + variant + " has allele frequency or counts '0'");
-        } else if (!canAlleleFrequenciesBeCalculated(variantSourceEntry)) {
+        if (!canAlleleFrequenciesBeCalculated(variantSourceEntry)) {
             throw new IncompleteInformationException(variant);
+        } else if (variantFrequencyIsZero(variantSourceEntry)) {
+            throw new NonVariantException("The variant " + variant + " has allele frequency or counts '0'");
         }
-    }
-
-    @Override
-    protected boolean isVariant(VariantSourceEntry variantSourceEntry) {
-        return !isAttributeZeroInVariantSourceEntry(variantSourceEntry, "AF") &&
-               !isAttributeZeroInVariantSourceEntry(variantSourceEntry, "AC") &&
-               !isAttributeZeroInVariantSourceEntry(variantSourceEntry, "AN");
-    }
-
-    protected boolean isAttributeZeroInVariantSourceEntry(VariantSourceEntry variantSourceEntry, String attribute) {
-        return variantSourceEntry.hasAttribute(attribute) && variantSourceEntry.getAttribute(attribute).equals("0");
     }
 
     protected boolean canAlleleFrequenciesBeCalculated(VariantSourceEntry variantSourceEntry) {
@@ -439,5 +430,16 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
 
         return frequenciesCanBeCalculated;
     }
+
+    protected boolean variantFrequencyIsZero(VariantSourceEntry variantSourceEntry) {
+        return isAttributeZeroInVariantSourceEntry(variantSourceEntry, "AF") ||
+               isAttributeZeroInVariantSourceEntry(variantSourceEntry, "AC") ||
+               isAttributeZeroInVariantSourceEntry(variantSourceEntry, "AN");
+    }
+
+    protected` boolean isAttributeZeroInVariantSourceEntry(VariantSourceEntry variantSourceEntry, String attribute) {
+        return variantSourceEntry.hasAttribute(attribute) && variantSourceEntry.getAttribute(attribute).equals("0");
+    }
+
 }
 

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -17,6 +17,7 @@
 package uk.ac.ebi.eva.commons.core.models.factories;
 
 import uk.ac.ebi.eva.commons.core.models.VariantStatistics;
+import uk.ac.ebi.eva.commons.core.models.factories.exception.NonVariantException;
 import uk.ac.ebi.eva.commons.core.models.genotype.Genotype;
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 import uk.ac.ebi.eva.commons.core.models.pipeline.VariantSourceEntry;
@@ -107,7 +108,7 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
     @Override
     protected void setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality,
                                   String filter, String info, String format, int numAllele, String[] alternateAlleles,
-                                  String line) {
+                                  String line) throws NonVariantException {
         // Fields not affected by the structure of REF and ALT fields
         variant.setIds(ids);
         VariantSourceEntry sourceEntry = variant.getSourceEntry(fileId, studyId);

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -411,7 +411,7 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
     protected void checkVariantInformation(Variant variant, String fileId, String studyId)
             throws NonVariantException, IncompleteInformationException {
         VariantSourceEntry variantSourceEntry = variant.getSourceEntry(fileId, studyId);
-        if (isNonVariant(variantSourceEntry)) {
+        if (!isVariant(variantSourceEntry)) {
             throw new NonVariantException("The variant " + variant + " has allele frequency or counts '0'");
         } else if (!canAlleleFrequenciesBeCalculated(variantSourceEntry)) {
             throw new IncompleteInformationException(variant);
@@ -419,13 +419,13 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
     }
 
     @Override
-    protected boolean isNonVariant(VariantSourceEntry variantSourceEntry){
-        return attributeIsZeroInVariantSourceEntry(variantSourceEntry, "AF") ||
-               attributeIsZeroInVariantSourceEntry(variantSourceEntry, "AC") ||
-               attributeIsZeroInVariantSourceEntry(variantSourceEntry, "AN");
+    protected boolean isVariant(VariantSourceEntry variantSourceEntry) {
+        return !isAttributeZeroInVariantSourceEntry(variantSourceEntry, "AF") &&
+               !isAttributeZeroInVariantSourceEntry(variantSourceEntry, "AC") &&
+               !isAttributeZeroInVariantSourceEntry(variantSourceEntry, "AN");
     }
 
-    protected boolean attributeIsZeroInVariantSourceEntry(VariantSourceEntry variantSourceEntry, String attribute) {
+    protected boolean isAttributeZeroInVariantSourceEntry(VariantSourceEntry variantSourceEntry, String attribute) {
         return variantSourceEntry.hasAttribute(attribute) && variantSourceEntry.getAttribute(attribute).equals("0");
     }
 

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -178,7 +178,7 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
      * @param attributes
      * @param variantStats
      */
-    protected void addStats(Variant variant, VariantSourceEntry sourceEntry, int numAllele, String[] alternateAlleles,
+    private void addStats(Variant variant, VariantSourceEntry sourceEntry, int numAllele, String[] alternateAlleles,
                             Map<String, String> attributes, VariantStatistics variantStats) {
 
         if (attributes.containsKey("AN") && attributes.containsKey("AC")) {
@@ -308,7 +308,7 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
         }
     }
 
-    protected Genotype parseGenotype(String gt, Variant variant, int numAllele, String[] alternateAlleles) {
+    private Genotype parseGenotype(String gt, Variant variant, int numAllele, String[] alternateAlleles) {
         Genotype g;
         Matcher m;
 

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -106,9 +106,9 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
     }
 
     @Override
-    protected void setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality,
-                                  String filter, String info, int numAllele, String[] alternateAlleles, String line) {
-        super.setOtherFields(variant, fileId, studyId, ids, quality, filter, info, numAllele, alternateAlleles, line);
+    protected void setOtherFields(Variant variant, String fileId, String studyId, float quality, String filter,
+                                  String info, int numAllele, String[] alternateAlleles, String line) {
+        super.setOtherFields(variant, fileId, studyId, quality, filter, info, numAllele, alternateAlleles, line);
 
         VariantSourceEntry variantSourceEntry = variant.getSourceEntry(fileId, studyId);
         if (tagMap == null) {

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -437,7 +437,7 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
                isAttributeZeroInVariantSourceEntry(variantSourceEntry, "AN");
     }
 
-    protected` boolean isAttributeZeroInVariantSourceEntry(VariantSourceEntry variantSourceEntry, String attribute) {
+    protected boolean isAttributeZeroInVariantSourceEntry(VariantSourceEntry variantSourceEntry, String attribute) {
         return variantSourceEntry.hasAttribute(attribute) && variantSourceEntry.getAttribute(attribute).equals("0");
     }
 

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -109,20 +109,7 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
     @Override
     protected void setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality,
                                   String filter, String info, int numAllele, String[] alternateAlleles, String line) {
-        // Fields not affected by the structure of REF and ALT fields
-        variant.setIds(ids);
-        VariantSourceEntry sourceEntry = variant.getSourceEntry(fileId, studyId);
-        if (quality > -1) {
-            sourceEntry.addAttribute("QUAL", String.valueOf(quality));
-        }
-        if (!filter.isEmpty()) {
-            sourceEntry.addAttribute("FILTER", filter);
-        }
-        if (!info.isEmpty()) {
-            parseInfo(variant, fileId, studyId, info, numAllele);
-        }
-        sourceEntry.addAttribute("src", line);
-
+        super.setOtherFields(variant, fileId, studyId, ids, quality, filter, info, numAllele, alternateAlleles, line);
 
         if (tagMap == null) {
             parseStats(variant, fileId, studyId, numAllele, alternateAlleles, info);

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -111,16 +111,16 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
                                   String filter, String info, int numAllele, String[] alternateAlleles, String line) {
         super.setOtherFields(variant, fileId, studyId, ids, quality, filter, info, numAllele, alternateAlleles, line);
 
+        VariantSourceEntry variantSourceEntry = variant.getSourceEntry(fileId, studyId);
         if (tagMap == null) {
-            parseStats(variant, fileId, studyId, numAllele, alternateAlleles, info);
+            parseStats(variant, variantSourceEntry, numAllele, alternateAlleles, info);
         } else {
-            parseCohortStats(variant, fileId, studyId, numAllele, alternateAlleles, info);
+            parseCohortStats(variant, variantSourceEntry, numAllele, alternateAlleles, info);
         }
     }
 
-    protected void parseStats(Variant variant, String fileId, String studyId, int numAllele, String[] alternateAlleles,
+    protected void parseStats(Variant variant, VariantSourceEntry sourceEntry, int numAllele, String[] alternateAlleles,
                               String info) {
-        VariantSourceEntry file = variant.getSourceEntry(fileId, studyId);
         VariantStatistics vs = new VariantStatistics(variant);
         Map<String, String> stats = new LinkedHashMap<>();
         String[] splittedInfo = info.split(";");
@@ -133,14 +133,13 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
             }
         }
 
-        addStats(variant, file, numAllele, alternateAlleles, stats, vs);
+        addStats(variant, sourceEntry, numAllele, alternateAlleles, stats, vs);
 
-        file.setStats(vs);
+        sourceEntry.setStats(vs);
     }
 
-    protected void parseCohortStats(Variant variant, String fileId, String studyId, int numAllele,
+    protected void parseCohortStats(Variant variant, VariantSourceEntry sourceEntry, int numAllele,
                                     String[] alternateAlleles, String info) {
-        VariantSourceEntry file = variant.getSourceEntry(fileId, studyId);
         Map<String, Map<String, String>> cohortStats = new LinkedHashMap<>();
         // cohortName -> (statsName -> statsValue): EUR->(AC->3,2)
         String[] splittedInfo = info.split(";");
@@ -163,10 +162,9 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
 
         for (String cohortName : cohortStats.keySet()) {
             VariantStatistics vs = new VariantStatistics(variant);
-            addStats(variant, file, numAllele, alternateAlleles, cohortStats.get(cohortName), vs);
-            file.setCohortStats(cohortName, vs);
+            addStats(variant, sourceEntry, numAllele, alternateAlleles, cohortStats.get(cohortName), vs);
+            sourceEntry.setCohortStats(cohortName, vs);
         }
-
     }
 
     /**

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -97,8 +97,7 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
     }
 
     @Override
-    protected void parseSplitSampleData(Variant variant, String fileId, String studyId, String[] fields,
-                                        String[] alternateAlleles, String[] secondaryAlternates,
+    protected void parseSplitSampleData(VariantSourceEntry variantSourceEntry, String[] fields,
                                         int alternateAlleleIdx) {
         if (fields.length > 8) {
             throw new IllegalArgumentException("Aggregated VCFs should not have column FORMAT nor " +

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -108,8 +108,7 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
 
     @Override
     protected void setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality,
-                                  String filter, String info, String format, int numAllele, String[] alternateAlleles,
-                                  String line) {
+                                  String filter, String info, int numAllele, String[] alternateAlleles, String line) {
         // Fields not affected by the structure of REF and ALT fields
         variant.setIds(ids);
         VariantSourceEntry sourceEntry = variant.getSourceEntry(fileId, studyId);
@@ -122,7 +121,6 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
         if (!info.isEmpty()) {
             parseInfo(variant, fileId, studyId, info, numAllele);
         }
-        sourceEntry.setFormat(format);
         sourceEntry.addAttribute("src", line);
 
 

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -17,7 +17,6 @@
 package uk.ac.ebi.eva.commons.core.models.factories;
 
 import uk.ac.ebi.eva.commons.core.models.VariantStatistics;
-import uk.ac.ebi.eva.commons.core.models.factories.exception.NonVariantException;
 import uk.ac.ebi.eva.commons.core.models.genotype.Genotype;
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 import uk.ac.ebi.eva.commons.core.models.pipeline.VariantSourceEntry;
@@ -96,20 +95,19 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
     }
 
     @Override
-    protected boolean parseSplitSampleData(Variant variant, String fileId, String studyId, String[] fields,
+    protected void parseSplitSampleData(Variant variant, String fileId, String studyId, String[] fields,
                                         String[] alternateAlleles, String[] secondaryAlternates,
                                         int alternateAlleleIdx) {
         if (fields.length > 8) {
             throw new IllegalArgumentException("Aggregated VCFs should not have column FORMAT nor " +
                     "further sample columns, i.e. there should be only 8 columns");
         }
-        return false;
     }
 
     @Override
-    protected boolean setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality,
+    protected void setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality,
                                   String filter, String info, String format, int numAllele, String[] alternateAlleles,
-                                  String line) throws NonVariantException {
+                                  String line) {
         // Fields not affected by the structure of REF and ALT fields
         variant.setIds(ids);
         VariantSourceEntry sourceEntry = variant.getSourceEntry(fileId, studyId);
@@ -119,9 +117,8 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
         if (!filter.isEmpty()) {
             sourceEntry.addAttribute("FILTER", filter);
         }
-        boolean hasCountsOrFrequenciesInInfoField = false;
         if (!info.isEmpty()) {
-            hasCountsOrFrequenciesInInfoField = parseInfo(variant, fileId, studyId, info, numAllele);
+            parseInfo(variant, fileId, studyId, info, numAllele);
         }
         sourceEntry.setFormat(format);
         sourceEntry.addAttribute("src", line);
@@ -132,8 +129,6 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
         } else {
             parseCohortStats(variant, fileId, studyId, numAllele, alternateAlleles, info);
         }
-
-        return hasCountsOrFrequenciesInInfoField;
     }
 
     protected void parseStats(Variant variant, String fileId, String studyId, int numAllele, String[] alternateAlleles,

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -436,7 +436,7 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
         return frequenciesCanBeCalculated;
     }
 
-    private boolean isVariantInfoAttributeZero(VariantSourceEntry variantSourceEntry, String attribute) {
+    protected boolean isVariantInfoAttributeZero(VariantSourceEntry variantSourceEntry, String attribute) {
         return variantSourceEntry.hasAttribute(attribute) && variantSourceEntry.getAttribute(attribute).equals("0");
     }
 }

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 EMBL - European Bioinformatics Institute
+ * Copyright 2014-2018 EMBL - European Bioinformatics Institute
  * Copyright 2015 OpenCB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,8 +31,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Overrides the methods in VariantVcfFactory that take care of the samples, in order to handle aggregated VCF files
- * which have no samples data (e.g. genotypes).
+ * Implementation of {@link VariantVcfFactory} that handles aggregated VCF files which
+ * have no samples data (e.g. genotypes).
  */
 public class VariantAggregatedVcfFactory extends VariantVcfFactory {
 

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -96,17 +96,18 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
     }
 
     @Override
-    protected void parseSplitSampleData(Variant variant, String fileId, String studyId, String[] fields,
+    protected boolean parseSplitSampleData(Variant variant, String fileId, String studyId, String[] fields,
                                         String[] alternateAlleles, String[] secondaryAlternates,
                                         int alternateAlleleIdx) {
         if (fields.length > 8) {
             throw new IllegalArgumentException("Aggregated VCFs should not have column FORMAT nor " +
                     "further sample columns, i.e. there should be only 8 columns");
         }
+        return false;
     }
 
     @Override
-    protected void setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality,
+    protected boolean setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality,
                                   String filter, String info, String format, int numAllele, String[] alternateAlleles,
                                   String line) throws NonVariantException {
         // Fields not affected by the structure of REF and ALT fields
@@ -118,8 +119,9 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
         if (!filter.isEmpty()) {
             sourceEntry.addAttribute("FILTER", filter);
         }
+        boolean hasCountsOrFrequenciesInInfoField = false;
         if (!info.isEmpty()) {
-            parseInfo(variant, fileId, studyId, info, numAllele);
+            hasCountsOrFrequenciesInInfoField = parseInfo(variant, fileId, studyId, info, numAllele);
         }
         sourceEntry.setFormat(format);
         sourceEntry.addAttribute("src", line);
@@ -130,6 +132,8 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
         } else {
             parseCohortStats(variant, fileId, studyId, numAllele, alternateAlleles, info);
         }
+
+        return hasCountsOrFrequenciesInInfoField;
     }
 
     protected void parseStats(Variant variant, String fileId, String studyId, int numAllele, String[] alternateAlleles,

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -420,9 +420,13 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
 
     @Override
     protected boolean isNonVariant(VariantSourceEntry variantSourceEntry){
-        return isVariantInfoAttributeZero(variantSourceEntry, "AF") ||
-               isVariantInfoAttributeZero(variantSourceEntry, "AC") ||
-               isVariantInfoAttributeZero(variantSourceEntry, "AN");
+        return attributeIsZeroInVariantSourceEntry(variantSourceEntry, "AF") ||
+               attributeIsZeroInVariantSourceEntry(variantSourceEntry, "AC") ||
+               attributeIsZeroInVariantSourceEntry(variantSourceEntry, "AN");
+    }
+
+    protected boolean attributeIsZeroInVariantSourceEntry(VariantSourceEntry variantSourceEntry, String attribute) {
+        return variantSourceEntry.hasAttribute(attribute) && variantSourceEntry.getAttribute(attribute).equals("0");
     }
 
     protected boolean canAlleleFrequenciesBeCalculated(VariantSourceEntry variantSourceEntry) {
@@ -434,10 +438,6 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
         }
 
         return frequenciesCanBeCalculated;
-    }
-
-    protected boolean isVariantInfoAttributeZero(VariantSourceEntry variantSourceEntry, String attribute) {
-        return variantSourceEntry.hasAttribute(attribute) && variantSourceEntry.getAttribute(attribute).equals("0");
     }
 }
 

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantGenotypedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantGenotypedVcfFactory.java
@@ -1,0 +1,124 @@
+package uk.ac.ebi.eva.commons.core.models.factories;
+
+import uk.ac.ebi.eva.commons.core.models.factories.exception.IncompleteInformationException;
+import uk.ac.ebi.eva.commons.core.models.factories.exception.NonVariantException;
+import uk.ac.ebi.eva.commons.core.models.genotype.Genotype;
+import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
+import uk.ac.ebi.eva.commons.core.models.pipeline.VariantSourceEntry;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class VariantGenotypedVcfFactory extends VariantVcfFactory {
+
+    protected void parseSplitSampleData(Variant variant, String fileId, String studyId, String[] fields,
+                                        String[] alternateAlleles, String[] secondaryAlternates,
+                                        int alternateAlleleIdx) {
+        if (fields.length < 9) {
+            throw new IllegalArgumentException("Genotyped VCFs should have column FORMAT and at least one further " +
+                                                       "sample columns, i.e. there should be at least 10 columns");
+        }
+
+        String[] formatFields = variant.getSourceEntry(fileId, studyId).getFormat().split(":");
+
+        for (int i = 9; i < fields.length; i++) {
+            Map<String, String> map = new TreeMap<>();
+
+            // Fill map of a sample
+            String[] sampleFields = fields[i].split(":");
+
+            // Samples may remove the trailing fields (only GT is mandatory),
+            // so the loop iterates to sampleFields.length, not formatFields.length
+            for (int j = 0; j < sampleFields.length; j++) {
+                String formatField = formatFields[j];
+                String sampleField = processSampleField(alternateAlleleIdx, formatField, sampleFields[j]);
+
+                map.put(formatField, sampleField);
+            }
+
+            // Add sample to the variant entry in the source file
+            variant.getSourceEntry(fileId, studyId).addSampleData(map);
+        }
+    }
+
+
+    /**
+     * If this is a field other than the genotype (GT), return unmodified. Otherwise,
+     * see {@link VariantGenotypedVcfFactory#processGenotypeField(int, java.lang.String)}
+     *
+     * @param alternateAlleleIdx current alternate being processed. 0 for first alternate, 1 or more for a secondary alternate.
+     * @param formatField as shown in the FORMAT column. most probably the GT field.
+     * @param sampleField parsed value in a column of a sample, such as a genotype, e.g. "0/0".
+     * @return processed sample field, ready to be stored.
+     */
+    private String processSampleField(int alternateAlleleIdx, String formatField, String sampleField) {
+        if (formatField.equalsIgnoreCase("GT")) {
+            return processGenotypeField(alternateAlleleIdx, sampleField);
+        } else {
+            return sampleField;
+        }
+    }
+
+    /**
+     * Intern the genotype String into the String pool to avoid storing lots of "0/0". In case that the variant is
+     * multiallelic and we are currently processing one of the secondary alternates (T is the only secondary alternate
+     * in a variant like A -> C,T), change the allele codes to represent the current alternate as allele 1. For details
+     * on changing this indexes, see {@link VariantVcfFactory#mapToMultiallelicIndex(int, int)}
+     *
+     * @param alternateAlleleIdx current alternate being processed. 0 for first alternate, 1 or more for a secondary alternate.
+     * @param genotype first field in the samples column, e.g. "0/0"
+     * @return the processed genotype string, as described above (interned and changed if multiallelic).
+     */
+    private String processGenotypeField(int alternateAlleleIdx, String genotype) {
+        boolean isNotTheFirstAlternate = alternateAlleleIdx >= 1;
+        if (isNotTheFirstAlternate) {
+            Genotype parsedGenotype = new Genotype(genotype);
+
+            StringBuilder genotypeStr = new StringBuilder();
+            for (int allele : parsedGenotype.getAllelesIdx()) {
+                if (allele < 0) { // Missing
+                    genotypeStr.append(".");
+                } else {
+                    // Replace numerical indexes when they refer to another alternate allele
+                    genotypeStr.append(String.valueOf(mapToMultiallelicIndex(allele, alternateAlleleIdx)));
+                }
+                genotypeStr.append(parsedGenotype.isPhased() ? "|" : "/");
+            }
+            genotype = genotypeStr.substring(0, genotypeStr.length() - 1);
+        }
+
+        return genotype.intern();
+    }
+
+    @Override
+    protected void checkVariantInformation(Variant variant, String fileId, String studyId)
+            throws NonVariantException, IncompleteInformationException {
+        super.checkVariantInformation(variant, fileId, studyId);
+        VariantSourceEntry variantSourceEntry = variant.getSourceEntry(fileId, studyId);
+        if (!hasAlternateAlleleCalls(variantSourceEntry)) {
+            throw new NonVariantException("The variant " + variant + " has no alternate allele genotype calls");
+        }
+    }
+
+    private boolean hasAlternateAlleleCalls(VariantSourceEntry variantSourceEntry) {
+        boolean hasAlternateAlleleCalls = false;
+
+        List<Map<String, String>> samplesData = variantSourceEntry.getSamplesData();
+        if (!samplesData.isEmpty()) {
+            if (samplesData.stream().map(m -> m.get("GT")).anyMatch(this::genotypeHasAlternateAllele)) {
+                hasAlternateAlleleCalls = true;
+            }
+        }
+
+        return hasAlternateAlleleCalls;
+    }
+
+
+    private boolean genotypeHasAlternateAllele(String sampleField) {
+        // the alternate allele index could be originally other than 1, but the processGenotypeField method has
+        // updated those indexes so all calls to the alternate allele in this variant has now index 1
+        return Arrays.stream(sampleField.split("[/|]")).anyMatch(allele -> allele.equals("1"));
+    }
+}

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantGenotypedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantGenotypedVcfFactory.java
@@ -33,9 +33,7 @@ public class VariantGenotypedVcfFactory extends VariantVcfFactory {
             // so the loop iterates to sampleFields.length, not formatFields.length
             for (int j = 0; j < sampleFields.length; j++) {
                 String formatField = formatFields[j];
-                String sampleField = processSampleField(alternateAlleleIdx, formatField, sampleFields[j]);
-
-                map.put(formatField, sampleField);
+                map.put(formatField, processSampleField(alternateAlleleIdx, formatField, sampleFields[j]));
             }
 
             // Add sample to the variant entry in the source file

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantGenotypedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantGenotypedVcfFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uk.ac.ebi.eva.commons.core.models.factories;
 
 import uk.ac.ebi.eva.commons.core.models.factories.exception.IncompleteInformationException;
@@ -11,6 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+
+/**
+ * Implementation of {@link VariantVcfFactory} that can parse VCF files with sample data, like genotypes
+ */
 public class VariantGenotypedVcfFactory extends VariantVcfFactory {
 
     protected void parseSplitSampleData(VariantSourceEntry variantSourceEntry, String[] fields,

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantGenotypedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantGenotypedVcfFactory.java
@@ -13,15 +13,14 @@ import java.util.TreeMap;
 
 public class VariantGenotypedVcfFactory extends VariantVcfFactory {
 
-    protected void parseSplitSampleData(Variant variant, String fileId, String studyId, String[] fields,
-                                        String[] alternateAlleles, String[] secondaryAlternates,
+    protected void parseSplitSampleData(VariantSourceEntry variantSourceEntry, String[] fields,
                                         int alternateAlleleIdx) {
         if (fields.length < 9) {
             throw new IllegalArgumentException("Genotyped VCFs should have column FORMAT and at least one further " +
                                                        "sample columns, i.e. there should be at least 10 columns");
         }
 
-        String[] formatFields = variant.getSourceEntry(fileId, studyId).getFormat().split(":");
+        String[] formatFields = variantSourceEntry.getFormat().split(":");
 
         for (int i = 9; i < fields.length; i++) {
             Map<String, String> map = new TreeMap<>();
@@ -37,7 +36,7 @@ public class VariantGenotypedVcfFactory extends VariantVcfFactory {
             }
 
             // Add sample to the variant entry in the source file
-            variant.getSourceEntry(fileId, studyId).addSampleData(map);
+            variantSourceEntry.addSampleData(map);
         }
     }
 

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
@@ -64,8 +64,7 @@ public class VariantVcfEVSFactory extends VariantAggregatedVcfFactory {
 
     @Override
     protected void setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality,
-                                  String filter, String info, String format, int numAllele, String[] alternateAlleles,
-                                  String line) {
+                                  String filter, String info, int numAllele, String[] alternateAlleles, String line) {
         // Fields not affected by the structure of REF and ALT fields
         variant.setIds(ids);
         VariantSourceEntry sourceEntry = variant.getSourceEntry(fileId, studyId);
@@ -78,9 +77,7 @@ public class VariantVcfEVSFactory extends VariantAggregatedVcfFactory {
         if (!info.isEmpty()) {
             parseInfo(variant, fileId, studyId, info, numAllele);
         }
-        sourceEntry.setFormat(format);
         sourceEntry.addAttribute("src", line);
-
 
         if (tagMap == null) {   // whether we can parse population stats or not
             parseEVSAttributes(variant, fileId, studyId, numAllele, alternateAlleles);

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
@@ -21,7 +21,6 @@ import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 import uk.ac.ebi.eva.commons.core.models.pipeline.VariantSourceEntry;
 
 import java.util.Properties;
-import java.util.Set;
 
 /**
  * Overrides the methods in VariantAggregatedVcfFactory that take care of the fields QUAL, FILTER and INFO, to support

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
@@ -179,8 +179,8 @@ public class VariantVcfEVSFactory extends VariantAggregatedVcfFactory {
 
     @Override
     protected boolean isNonVariant(VariantSourceEntry variantSourceEntry){
-        return isVariantInfoAttributeZero(variantSourceEntry, "TAC") ||
-                isVariantInfoAttributeZero(variantSourceEntry, "AN");
+        return attributeIsZeroInVariantSourceEntry(variantSourceEntry, "TAC") ||
+                attributeIsZeroInVariantSourceEntry(variantSourceEntry, "AN");
     }
 
     @Override

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
@@ -71,8 +71,8 @@ public class VariantVcfEVSFactory extends VariantAggregatedVcfFactory {
             }
         }
 
-        if (sourceEntry.hasAttribute("GTS") && sourceEntry.hasAttribute("GTC")) {
-            String splitsGTC[] = sourceEntry.getAttribute("GTC").split(",");
+        if (sourceEntry.hasAttribute(GENOTYPE_STRING) && sourceEntry.hasAttribute(GENOTYPE_COUNT)) {
+            String splitsGTC[] = sourceEntry.getAttribute(GENOTYPE_COUNT).split(",");
             addGenotypeWithGTS(variant, sourceEntry, splitsGTC, alternateAlleles, numAllele, stats);
         }
 
@@ -96,19 +96,19 @@ public class VariantVcfEVSFactory extends VariantAggregatedVcfFactory {
                             sourceEntry.setCohortStats(cohort, cohortStats);
                         }
                         switch (opencgaTagSplit[1]) {
-                            case "AC":
+                            case ALLELE_COUNT:
                                 cohortStats.setAltAlleleCount(Integer.parseInt(values[numAllele]));
                                 cohortStats.setRefAlleleCount(Integer.parseInt(
                                         values[values.length - 1]));    // ref allele count is the last one
                                 break;
-                            case "AF":
+                            case ALLELE_FREQUENCY:
                                 cohortStats.setAltAlleleFreq(Float.parseFloat(values[numAllele]));
                                 cohortStats.setRefAlleleFreq(Float.parseFloat(values[values.length - 1]));
                                 break;
-                            case "AN":
+                            case ALLELE_NUMBER:
                                 // TODO implement this. also, take into account that needed fields may not be processed yet
                                 break;
-                            case "GTC":
+                            case GENOTYPE_COUNT:
                                 addGenotypeWithGTS(variant, sourceEntry, values, alternateAlleles, numAllele,
                                                    cohortStats);
                                 break;
@@ -140,13 +140,13 @@ public class VariantVcfEVSFactory extends VariantAggregatedVcfFactory {
 
     @Override
     protected boolean canAlleleFrequenciesBeCalculated(VariantSourceEntry variantSourceEntry) {
-        return variantSourceEntry.hasAttribute("GTS") && variantSourceEntry.hasAttribute("GTC");
+        return variantSourceEntry.hasAttribute(GENOTYPE_STRING) && variantSourceEntry.hasAttribute(GENOTYPE_COUNT);
     }
 
     @Override
     protected boolean variantFrequencyIsZero(VariantSourceEntry variantSourceEntry) {
         return isAttributeZeroInVariantSourceEntry(variantSourceEntry, "TAC") ||
-                isAttributeZeroInVariantSourceEntry(variantSourceEntry, "AN");
+                isAttributeZeroInVariantSourceEntry(variantSourceEntry, ALLELE_NUMBER);
     }
 }
 

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 EMBL - European Bioinformatics Institute
+ * Copyright 2014-2018 EMBL - European Bioinformatics Institute
  * Copyright 2015 OpenCB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
@@ -167,30 +167,14 @@ public class VariantVcfEVSFactory extends VariantAggregatedVcfFactory {
     }
 
     @Override
-    protected void checkVariantInformation(Variant variant, String fileId, String studyId)
-            throws NonVariantException, IncompleteInformationException {
-        VariantSourceEntry variantSourceEntry = variant.getSourceEntry(fileId, studyId);
-        if (isNonVariant(variantSourceEntry)) {
-            throw new NonVariantException("The variant " + variant + " has allele frequency or counts '0'");
-        } else if (!canAlleleFrequenciesBeCalculated(variantSourceEntry)) {
-            throw new IncompleteInformationException(variant);
-        }
-    }
-
-    @Override
-    protected boolean isNonVariant(VariantSourceEntry variantSourceEntry){
-        return attributeIsZeroInVariantSourceEntry(variantSourceEntry, "TAC") ||
-                attributeIsZeroInVariantSourceEntry(variantSourceEntry, "AN");
+    protected boolean isVariant(VariantSourceEntry variantSourceEntry) {
+        return !isAttributeZeroInVariantSourceEntry(variantSourceEntry, "TAC") &&
+                !isAttributeZeroInVariantSourceEntry(variantSourceEntry, "AN");
     }
 
     @Override
     protected boolean canAlleleFrequenciesBeCalculated(VariantSourceEntry variantSourceEntry) {
-        boolean frequenciesCanBeCalculated = false;
-        if (variantSourceEntry.hasAttribute("GTS") && variantSourceEntry.hasAttribute("GTC")) {
-            frequenciesCanBeCalculated = true;
-        }
-
-        return frequenciesCanBeCalculated;
+        return variantSourceEntry.hasAttribute("GTS") && variantSourceEntry.hasAttribute("GTC");
     }
 
 }

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
@@ -17,6 +17,7 @@
 package uk.ac.ebi.eva.commons.core.models.factories;
 
 import uk.ac.ebi.eva.commons.core.models.VariantStatistics;
+import uk.ac.ebi.eva.commons.core.models.factories.exception.NonVariantException;
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 import uk.ac.ebi.eva.commons.core.models.pipeline.VariantSourceEntry;
 
@@ -63,7 +64,7 @@ public class VariantVcfEVSFactory extends VariantAggregatedVcfFactory {
     @Override
     protected void setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality,
                                   String filter, String info, String format, int numAllele, String[] alternateAlleles,
-                                  String line) {
+                                  String line) throws NonVariantException {
         // Fields not affected by the structure of REF and ALT fields
         variant.setIds(ids);
         VariantSourceEntry sourceEntry = variant.getSourceEntry(fileId, studyId);

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
@@ -167,15 +167,14 @@ public class VariantVcfEVSFactory extends VariantAggregatedVcfFactory {
     }
 
     @Override
-    protected boolean isVariant(VariantSourceEntry variantSourceEntry) {
-        return !isAttributeZeroInVariantSourceEntry(variantSourceEntry, "TAC") &&
-                !isAttributeZeroInVariantSourceEntry(variantSourceEntry, "AN");
-    }
-
-    @Override
     protected boolean canAlleleFrequenciesBeCalculated(VariantSourceEntry variantSourceEntry) {
         return variantSourceEntry.hasAttribute("GTS") && variantSourceEntry.hasAttribute("GTC");
     }
 
+    @Override
+    protected boolean variantFrequencyIsZero(VariantSourceEntry variantSourceEntry) {
+        return isAttributeZeroInVariantSourceEntry(variantSourceEntry, "TAC") ||
+                isAttributeZeroInVariantSourceEntry(variantSourceEntry, "AN");
+    }
 }
 

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactory.java
@@ -61,30 +61,28 @@ public class VariantVcfEVSFactory extends VariantAggregatedVcfFactory {
     }
 
     @Override
-    protected void parseStats(Variant variant, String fileId, String studyId, int numAllele, String[] alternateAlleles,
+    protected void parseStats(Variant variant, VariantSourceEntry sourceEntry, int numAllele, String[] alternateAlleles,
                             String info) {
-        VariantSourceEntry file = variant.getSourceEntry(fileId, studyId);
         VariantStatistics stats = new VariantStatistics(variant);
-        if (file.hasAttribute("MAF")) {
-            String splitsMAF[] = file.getAttribute("MAF").split(",");
+        if (sourceEntry.hasAttribute("MAF")) {
+            String splitsMAF[] = sourceEntry.getAttribute("MAF").split(",");
             if (splitsMAF.length == 3) {
                 float maf = Float.parseFloat(splitsMAF[2]) / 100;
                 stats.setMaf(maf);
             }
         }
 
-        if (file.hasAttribute("GTS") && file.hasAttribute("GTC")) {
-            String splitsGTC[] = file.getAttribute("GTC").split(",");
-            addGenotypeWithGTS(variant, file, splitsGTC, alternateAlleles, numAllele, stats);
+        if (sourceEntry.hasAttribute("GTS") && sourceEntry.hasAttribute("GTC")) {
+            String splitsGTC[] = sourceEntry.getAttribute("GTC").split(",");
+            addGenotypeWithGTS(variant, sourceEntry, splitsGTC, alternateAlleles, numAllele, stats);
         }
 
-        file.setStats(stats);
+        sourceEntry.setStats(stats);
     }
 
     @Override
-    protected void parseCohortStats(Variant variant, String fileId, String studyId, int numAllele,
+    protected void parseCohortStats(Variant variant, VariantSourceEntry sourceEntry, int numAllele,
                                     String[] alternateAlleles, String info) {
-        VariantSourceEntry sourceEntry = variant.getSourceEntry(fileId, studyId);
         if (tagMap != null) {
             for (String key : sourceEntry.getAttributes().keySet()) {
                 String opencgaTag = reverseTagMap.get(key);

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfExacFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfExacFactory.java
@@ -71,9 +71,8 @@ public class VariantVcfExacFactory extends VariantAggregatedVcfFactory {
     }
 
     @Override
-    protected void parseStats(Variant variant, String fileId, String studyId, int numAllele, String[] alternateAlleles,
+    protected void parseStats(Variant variant, VariantSourceEntry sourceEntry, int numAllele, String[] alternateAlleles,
                               String info) {
-        VariantSourceEntry sourceEntry = variant.getSourceEntry(fileId, studyId);
         VariantStatistics stats = new VariantStatistics(variant);
 
         if (sourceEntry.hasAttribute(AC_HET)) {   // heterozygous genotype count
@@ -116,9 +115,8 @@ public class VariantVcfExacFactory extends VariantAggregatedVcfFactory {
 
 
     @Override
-    protected void parseCohortStats(Variant variant, String fileId, String studyId, int numAllele, String[] alternateAlleles,
-                                    String info) {
-        VariantSourceEntry sourceEntry = variant.getSourceEntry(fileId, studyId);
+    protected void parseCohortStats(Variant variant, VariantSourceEntry sourceEntry, int numAllele,
+                                    String[] alternateAlleles, String info) {
         String[] attributes = info.split(";");
         Map<String, Integer> ans = new LinkedHashMap<>();
         Map<String, String[]> acs = new LinkedHashMap<>();

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfExacFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfExacFactory.java
@@ -134,11 +134,11 @@ public class VariantVcfExacFactory extends VariantAggregatedVcfFactory {
                         sourceEntry.setCohortStats(cohortName, cohortStats);
                     }
                     switch (opencgaTagSplit[1]) {
-                        case "AC":
+                        case ALLELE_COUNT:
                             cohortStats.setAltAlleleCount(Integer.parseInt(values[numAllele]));
                             acs.put(cohortName, values);
                             break;
-                        case "AN":
+                        case ALLELE_NUMBER:
                             ans.put(cohortName, Integer.parseInt(values[0]));
                             break;
                         case "HET":

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfExacFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfExacFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 EMBL - European Bioinformatics Institute
+ * Copyright 2014-2018 EMBL - European Bioinformatics Institute
  * Copyright 2015 OpenCB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
@@ -362,9 +362,8 @@ public class VariantVcfFactory {
         return correctedAllele;
     }
 
-    private void checkVariantInformation(Variant variant, String fileId,
-                                           String studyId) throws NonVariantException, IncompleteInformationException {
-
+    private void checkVariantInformation(Variant variant, String fileId, String studyId)
+            throws NonVariantException, IncompleteInformationException {
         // check genotypes
         VariantSourceEntry variantSourceEntry = variant.getSourceEntry(fileId, studyId);
         List<Map<String, String>> samplesData = variantSourceEntry.getSamplesData();

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
@@ -378,13 +378,15 @@ public class VariantVcfFactory {
             boolean hasAF = checkAttributeIsNotZero(variantSourceEntry, "AF");
             boolean hasAN =  checkAttributeIsNotZero(variantSourceEntry, "AN");
             boolean hasGTC =  checkAttributeIsNotZero(variantSourceEntry, "GTC");
-            if (!hasAC && !hasAF && !hasAN && !hasGTC) {
+            if (!hasAF && !hasGTC && !(hasAN && hasAC)) {
                 throw new IncompleteInformationException(variant);
             }
         }
     }
 
     private boolean genotypeHasAlternateAllele(String sampleField) {
+        // the alternate allele index could be originally other than 1, but the processGenotypeField method has
+        // updated those indexes so all calls to the alternate allele in this variant has now index 1
         return Arrays.stream(sampleField.split("[/|]")).anyMatch(allele -> allele.equals("1"));
     }
 

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
@@ -25,17 +25,20 @@ import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 import uk.ac.ebi.eva.commons.core.models.pipeline.VariantSourceEntry;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Class that parses VCF lines to create Variants.
  */
 public abstract class VariantVcfFactory {
+
+    public static final String ALLELE_FREQUENCY = "AF";
+
+    public static final String ALLELE_COUNT = "AC";
+
+    public static final String ALLELE_NUMBER = "AN";
 
     /**
      * Creates a list of Variant objects using the fields in a record of a VCF
@@ -188,15 +191,15 @@ public abstract class VariantVcfFactory {
             String[] splits = var.split("=");
             if (splits.length == 2) {
                 switch (splits[0]) {
-                    case "AC":
+                    case ALLELE_COUNT:
                         String[] counts = splits[1].split(",");
                         file.addAttribute(splits[0], counts[numAllele]);
                         break;
-                    case "AF":
+                    case ALLELE_FREQUENCY:
                         String[] frequencies = splits[1].split(",");
                         file.addAttribute(splits[0], frequencies[numAllele]);
                         break;
-                    case "AN":
+                    case ALLELE_NUMBER:
                         file.addAttribute(splits[0], splits[1]);
                         break;
                     case "NS":

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
@@ -281,17 +281,14 @@ public class VariantVcfFactory {
                         file.addAttribute(splits[0], ids[numAllele]);
                         break;
                     case "AC":
-                        // TODO For now, only one alternate is supported
                         String[] counts = splits[1].split(",");
                         file.addAttribute(splits[0], counts[numAllele]);
                         break;
                     case "AF":
-                        // TODO For now, only one alternate is supported
                         String[] frequencies = splits[1].split(",");
                         file.addAttribute(splits[0], frequencies[numAllele]);
                         break;
                     case "AN":
-//                        // TODO For now, only two alleles (reference and one alternate) are supported, but this should be changed
                         file.addAttribute(splits[0], splits[1]);
                         break;
                     case "NS":

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 EMBL - European Bioinformatics Institute
+ * Copyright 2014-2018 EMBL - European Bioinformatics Institute
  * Copyright 2015 OpenCB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Class that parses VCF lines to create Variants.
+ * Abstract class to parse the basic fields in VCF lines
  */
 public abstract class VariantVcfFactory {
 
@@ -62,20 +62,25 @@ public abstract class VariantVcfFactory {
             throw new IllegalArgumentException("Not enough fields provided (min 8)");
         }
 
+        String chromosome = getChromosomeWithoutPrefix(fields);
+        int position = getPosition(fields);
+        String reference = getReference(fields);
         String[] alternateAlleles = getAlternateAlleles(fields);
-        List<VariantCoreFields> generatedKeyFields = buildVariantCoreFields(fields, alternateAlleles);
 
         float quality = getQuality(fields);
         String filter = getFilter(fields);
         String info = getInfo(fields);
         String format = getFormat(fields);
 
+        List<VariantCoreFields> generatedKeyFields = buildVariantCoreFields(chromosome, position, reference,
+                                                                            alternateAlleles);
+
         List<Variant> variants = new LinkedList<>();
         // Now create all the Variant objects read from the VCF record
         for (int altAlleleIdx = 0; altAlleleIdx < alternateAlleles.length; altAlleleIdx++) {
             VariantCoreFields keyFields = generatedKeyFields.get(altAlleleIdx);
-            Variant variant = new Variant(keyFields.getChromosome(), keyFields.getStart(), keyFields.getEnd(),
-                                          keyFields.getReference(), keyFields.getAlternate());
+            Variant variant = new Variant(chromosome, keyFields.getStart(), keyFields.getEnd(), keyFields.getReference(),
+                                          keyFields.getAlternate());
             String[] secondaryAlternates = getSecondaryAlternates(altAlleleIdx, alternateAlleles);
             VariantSourceEntry file = new VariantSourceEntry(fileId, studyId, secondaryAlternates, format);
             variant.addSourceEntry(file);
@@ -90,28 +95,6 @@ public abstract class VariantVcfFactory {
         }
 
         return variants;
-    }
-
-    private String[] getAlternateAlleles(String[] fields) {
-        return fields[4].split(",");
-    }
-
-    private List<VariantCoreFields> buildVariantCoreFields(String[] fields, String[] alternateAlleles) {
-        List<VariantCoreFields> generatedKeyFields = new ArrayList<>();
-
-        String chromosome = getChromosomeWithoutPrefix(fields);
-        int position = getPosition(fields);
-        String reference = getReference(fields);
-        for (int i = 0; i < alternateAlleles.length; i++) { // This index is necessary for getting the samples where the mutated allele is present
-            VariantCoreFields keyFields = new VariantCoreFields(chromosome, position, reference, alternateAlleles[i]);
-
-            // Since the reference and alternate alleles won't necessarily match
-            // the ones read from the VCF file but they are still needed for
-            // instantiating the variants, they must be updated
-            alternateAlleles[i] = keyFields.getAlternate();
-            generatedKeyFields.add(keyFields);
-        }
-        return generatedKeyFields;
     }
 
     /**
@@ -137,6 +120,10 @@ public abstract class VariantVcfFactory {
         return fields[3].equals(".") ? "" : fields[3];
     }
 
+    private String[] getAlternateAlleles(String[] fields) {
+        return fields[4].split(",");
+    }
+
     private float getQuality(String[] fields) {
         return fields[5].equals(".") ? -1 : Float.parseFloat(fields[5]);
     }
@@ -153,8 +140,25 @@ public abstract class VariantVcfFactory {
         return (fields.length <= 8 || fields[8].equals(".")) ? "" : fields[8];
     }
 
+    private List<VariantCoreFields> buildVariantCoreFields(String chromosome, int position, String reference,
+                                                           String[] alternateAlleles) {
+        List<VariantCoreFields> generatedKeyFields = new ArrayList<>();
 
-    protected String[] getSecondaryAlternates(int numAllele, String[] alternateAlleles) {
+        for (int i = 0; i < alternateAlleles.length; i++) { // This index is necessary for getting the samples where
+            // the mutated allele is present
+            VariantCoreFields keyFields = new VariantCoreFields(chromosome, position, reference, alternateAlleles[i]);
+
+            // Since the reference and alternate alleles won't necessarily match
+            // the ones read from the VCF file but they are still needed for
+            // instantiating the variants, they must be updated
+            alternateAlleles[i] = keyFields.getAlternate();
+            generatedKeyFields.add(keyFields);
+        }
+        return generatedKeyFields;
+    }
+
+
+    private String[] getSecondaryAlternates(int numAllele, String[] alternateAlleles) {
         String[] secondaryAlternates = new String[alternateAlleles.length - 1];
         for (int i = 0, j = 0; i < alternateAlleles.length; i++) {
             if (i != numAllele) {
@@ -184,7 +188,7 @@ public abstract class VariantVcfFactory {
         variant.getSourceEntry(fileId, studyId).addAttribute("src", line);
     }
 
-    protected void parseInfo(Variant variant, String fileId, String studyId, String info, int numAllele) {
+    private void parseInfo(Variant variant, String fileId, String studyId, String info, int numAllele) {
         VariantSourceEntry file = variant.getSourceEntry(fileId, studyId);
 
         for (String var : info.split(";")) {

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import uk.ac.ebi.eva.commons.core.models.VariantCoreFields;
+import uk.ac.ebi.eva.commons.core.models.factories.exception.IncompleteInformationException;
 import uk.ac.ebi.eva.commons.core.models.factories.exception.NonVariantException;
 import uk.ac.ebi.eva.commons.core.models.genotype.Genotype;
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
@@ -53,11 +54,12 @@ public class VariantVcfFactory {
      *
      * @param fileId,
      * @param studyId
-     * @param line Contents of the line in the file
+     * @param line    Contents of the line in the file
      * @return The list of Variant objects that can be created using the fields from a VCF record
      */
     public List<Variant> create(String fileId, String studyId,
-                                String line) throws IllegalArgumentException, NonVariantException {
+                                String line) throws IllegalArgumentException, NonVariantException,
+            IncompleteInformationException {
 
         String[] fields = line.split("\t");
         if (fields.length < 8) {
@@ -88,11 +90,14 @@ public class VariantVcfFactory {
             VariantSourceEntry file = new VariantSourceEntry(fileId, studyId, secondaryAlternates, format);
             variant.addSourceEntry(file);
 
-            parseSplitSampleData(variant, fileId, studyId, fields, alternateAlleles, secondaryAlternates,
-                                 altAlleleIdx);
+            boolean hasSamplesData = parseSplitSampleData(variant, fileId, studyId, fields, alternateAlleles,
+                                                          secondaryAlternates, altAlleleIdx);
             // Fill the rest of fields (after samples because INFO depends on them)
-            setOtherFields(variant, fileId, studyId, ids, quality, filter, info, format, altAlleleIdx,
-                           alternateAlleles, line);
+            boolean hasFrequenciesOrAllelesCounts = setOtherFields(variant, fileId, studyId, ids, quality, filter, info,
+                                                                   format, altAlleleIdx, alternateAlleles, line);
+            if (!hasSamplesData && !hasFrequenciesOrAllelesCounts) {
+                throw new IncompleteInformationException(keyFields);
+            }
             variants.add(variant);
         }
 
@@ -176,40 +181,46 @@ public class VariantVcfFactory {
         return secondaryAlternates;
     }
 
-    protected void parseSplitSampleData(Variant variant, String fileId, String studyId, String[] fields,
+    protected boolean parseSplitSampleData(Variant variant, String fileId, String studyId, String[] fields,
                                         String[] alternateAlleles, String[] secondaryAlternates,
                                         int alternateAlleleIdx) throws NonVariantException {
+
         String[] formatFields = variant.getSourceEntry(fileId, studyId).getFormat().split(":");
 
-        // if there are no sample columns (fields.length < 9), there are no genotypes to check
-        boolean allGenotypesAreRefOrMissingValues = fields.length >= 9;
+        boolean hasSampleData = fields.length >= 9;
 
-        for (int i = 9; i < fields.length; i++) {
-            Map<String, String> map = new TreeMap<>();
+        if (hasSampleData) {
+            boolean allGenotypesAreRefOrMissingValues = true;
 
-            // Fill map of a sample
-            String[] sampleFields = fields[i].split(":");
+            for (int i = 9; i < fields.length; i++) {
+                Map<String, String> map = new TreeMap<>();
 
-            // Samples may remove the trailing fields (only GT is mandatory),
-            // so the loop iterates to sampleFields.length, not formatFields.length
-            for (int j = 0; j < sampleFields.length; j++) {
-                String formatField = formatFields[j];
-                String sampleField = processSampleField(alternateAlleleIdx, formatField, sampleFields[j]);
-                if (allGenotypesAreRefOrMissingValues && formatField.equalsIgnoreCase("GT")) {
-                    if (genotypeHasAlternateAllele(sampleField)) {
-                        allGenotypesAreRefOrMissingValues = false;
+                // Fill map of a sample
+                String[] sampleFields = fields[i].split(":");
+
+                // Samples may remove the trailing fields (only GT is mandatory),
+                // so the loop iterates to sampleFields.length, not formatFields.length
+                for (int j = 0; j < sampleFields.length; j++) {
+                    String formatField = formatFields[j];
+                    String sampleField = processSampleField(alternateAlleleIdx, formatField, sampleFields[j]);
+                    if (allGenotypesAreRefOrMissingValues && formatField.equalsIgnoreCase("GT")) {
+                        if (genotypeHasAlternateAllele(sampleField)) {
+                            allGenotypesAreRefOrMissingValues = false;
+                        }
                     }
+
+                    map.put(formatField, sampleField);
                 }
 
-                map.put(formatField, sampleField);
+                // Add sample to the variant entry in the source file
+                variant.getSourceEntry(fileId, studyId).addSampleData(map);
             }
+            if (allGenotypesAreRefOrMissingValues) {
+                throw new NonVariantException("All genotypes are reference or missing values");
+            }
+        }
 
-            // Add sample to the variant entry in the source file
-            variant.getSourceEntry(fileId, studyId).addSampleData(map);
-        }
-        if (allGenotypesAreRefOrMissingValues) {
-            throw new NonVariantException("All genotypes are reference or missing values");
-        }
+        return hasSampleData;
     }
 
     /**
@@ -264,7 +275,7 @@ public class VariantVcfFactory {
         return Arrays.stream(sampleField.split("[/|]")).anyMatch(allele -> allele.equals("1"));
     }
 
-    protected void setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality,
+    protected boolean setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality,
                                   String filter, String info, String format, int numAllele, String[] alternateAlleles,
                                   String line) throws NonVariantException {
 
@@ -278,16 +289,21 @@ public class VariantVcfFactory {
         if (!filter.isEmpty()) {
             variant.getSourceEntry(fileId, studyId).addAttribute("FILTER", filter);
         }
+
+        boolean hasCountsOrFrequenciesInInfoField = false;
         if (!info.isEmpty()) {
-            parseInfo(variant, fileId, studyId, info, numAllele);
+            hasCountsOrFrequenciesInInfoField = parseInfo(variant, fileId, studyId, info, numAllele);
         }
         variant.getSourceEntry(fileId, studyId).addAttribute("src", line);
+
+        return hasCountsOrFrequenciesInInfoField;
     }
 
-    protected void parseInfo(Variant variant, String fileId, String studyId, String info,
+    protected boolean parseInfo(Variant variant, String fileId, String studyId, String info,
                              int numAllele) throws NonVariantException {
 
         VariantSourceEntry file = variant.getSourceEntry(fileId, studyId);
+        boolean hasCountsOrFrequencies = false;
 
         for (String var : info.split(";")) {
             String[] splits = var.split("=");
@@ -305,6 +321,7 @@ public class VariantVcfFactory {
                             throw new NonVariantException("Alternate allele count is 0");
                         }
                         file.addAttribute(splits[0], counts[numAllele]);
+                        hasCountsOrFrequencies = true;
                         break;
                     case "AF":
                         // TODO For now, only one alternate is supported
@@ -313,6 +330,7 @@ public class VariantVcfFactory {
                             throw new NonVariantException("Alternate allele frequency is 0");
                         }
                         file.addAttribute(splits[0], frequencies[numAllele]);
+                        hasCountsOrFrequencies = true;
                         break;
                     case "AN":
 //                        // TODO For now, only two alleles (reference and one alternate) are supported, but this should be changed
@@ -359,7 +377,9 @@ public class VariantVcfFactory {
             } else {
                 variant.getSourceEntry(fileId, studyId).addAttribute(splits[0], "");
             }
+
         }
+        return hasCountsOrFrequencies;
     }
 
     /**

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
@@ -265,8 +265,10 @@ public class VariantVcfFactory {
         return Arrays.stream(sampleField.split("[/|]")).anyMatch(allele -> allele.equals("1"));
     }
 
-    protected void setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality, String filter,
-                                  String info, String format, int numAllele, String[] alternateAlleles, String line) {
+    protected void setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality,
+                                  String filter, String info, String format, int numAllele, String[] alternateAlleles,
+                                  String line) throws NonVariantException {
+
         // Fields not affected by the structure of REF and ALT fields
         variant.setIds(ids);
 
@@ -283,7 +285,9 @@ public class VariantVcfFactory {
         variant.getSourceEntry(fileId, studyId).addAttribute("src", line);
     }
 
-    protected void parseInfo(Variant variant, String fileId, String studyId, String info, int numAllele) {
+    protected void parseInfo(Variant variant, String fileId, String studyId, String info,
+                             int numAllele) throws NonVariantException {
+
         VariantSourceEntry file = variant.getSourceEntry(fileId, studyId);
 
         for (String var : info.split(";")) {
@@ -303,6 +307,9 @@ public class VariantVcfFactory {
                     case "AF":
                         // TODO For now, only one alternate is supported
                         String[] frequencies = splits[1].split(",");
+                        if (frequencies[numAllele].equals("0")) {
+                            throw new NonVariantException("Allele frequency is 0");
+                        }
                         file.addAttribute(splits[0], frequencies[numAllele]);
                         break;
 //                    case "AN":

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
@@ -302,13 +302,16 @@ public class VariantVcfFactory {
                     case "AC":
                         // TODO For now, only one alternate is supported
                         String[] counts = splits[1].split(",");
+                        if (counts[numAllele].equals("0")) {
+                            throw new NonVariantException("Alternate allele count is 0");
+                        }
                         file.addAttribute(splits[0], counts[numAllele]);
                         break;
                     case "AF":
                         // TODO For now, only one alternate is supported
                         String[] frequencies = splits[1].split(",");
                         if (frequencies[numAllele].equals("0")) {
-                            throw new NonVariantException("Allele frequency is 0");
+                            throw new NonVariantException("Alternate allele frequency is 0");
                         }
                         file.addAttribute(splits[0], frequencies[numAllele]);
                         break;

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
@@ -62,7 +62,6 @@ public abstract class VariantVcfFactory {
         String[] alternateAlleles = getAlternateAlleles(fields);
         List<VariantCoreFields> generatedKeyFields = buildVariantCoreFields(fields, alternateAlleles);
 
-        Set<String> ids = new HashSet<>(); //EVA-942 - Ignore IDs submitted through VCF
         float quality = getQuality(fields);
         String filter = getFilter(fields);
         String info = getInfo(fields);
@@ -80,7 +79,7 @@ public abstract class VariantVcfFactory {
 
             parseSplitSampleData(file, fields, altAlleleIdx);
             // Fill the rest of fields (after samples because INFO depends on them)
-            setOtherFields(variant, fileId, studyId, ids, quality, filter, info, altAlleleIdx, alternateAlleles, line);
+            setOtherFields(variant, fileId, studyId, quality, filter, info, altAlleleIdx, alternateAlleles, line);
 
             checkVariantInformation(variant, fileId, studyId);
 
@@ -166,11 +165,9 @@ public abstract class VariantVcfFactory {
                                                  int alternateAlleleIdx);
 
 
-    protected void setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality,
+    protected void setOtherFields(Variant variant, String fileId, String studyId, float quality,
                                   String filter, String info, int numAllele, String[] alternateAlleles, String line) {
         // Fields not affected by the structure of REF and ALT fields
-        variant.setIds(ids);
-
         if (quality > -1) {
             variant.getSourceEntry(fileId, studyId)
                    .addAttribute("QUAL", String.valueOf(quality));

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
@@ -84,8 +84,7 @@ public abstract class VariantVcfFactory {
 
             parseSplitSampleData(variant, fileId, studyId, fields, alternateAlleles, secondaryAlternates, altAlleleIdx);
             // Fill the rest of fields (after samples because INFO depends on them)
-            setOtherFields(variant, fileId, studyId, ids, quality, filter, info, format, altAlleleIdx,
-                           alternateAlleles, line);
+            setOtherFields(variant, fileId, studyId, ids, quality, filter, info, altAlleleIdx, alternateAlleles, line);
             checkVariantInformation(variant, fileId, studyId);
 
             variants.add(variant);
@@ -176,8 +175,8 @@ public abstract class VariantVcfFactory {
                                         int alternateAlleleIdx);
 
 
-    protected void setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality, String filter,
-                                  String info, String format, int numAllele, String[] alternateAlleles, String line) {
+    protected void setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality,
+                                  String filter, String info, int numAllele, String[] alternateAlleles, String line) {
         // Fields not affected by the structure of REF and ALT fields
         variant.setIds(ids);
 

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
@@ -314,10 +314,13 @@ public class VariantVcfFactory {
                         }
                         file.addAttribute(splits[0], frequencies[numAllele]);
                         break;
-//                    case "AN":
+                    case "AN":
 //                        // TODO For now, only two alleles (reference and one alternate) are supported, but this should be changed
 //                        file.addAttribute(splits[0], "2");
-//                        break;
+                        if (splits[1].equals("0")) {
+                            throw new NonVariantException("Total number of alleles is 0");
+                        }
+                        break;
                     case "NS":
                         // Count the number of samples that are associated with the allele
                         file.addAttribute(splits[0], String.valueOf(file.getSamplesData().size()));

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
@@ -362,7 +362,7 @@ public class VariantVcfFactory {
         return correctedAllele;
     }
 
-    protected void checkVariantInformation(Variant variant, String fileId,
+    private void checkVariantInformation(Variant variant, String fileId,
                                            String studyId) throws NonVariantException, IncompleteInformationException {
 
         // check genotypes

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
@@ -275,11 +275,6 @@ public class VariantVcfFactory {
             String[] splits = var.split("=");
             if (splits.length == 2) {
                 switch (splits[0]) {
-                    case "ACC":
-                        // Managing accession ID for the allele
-                        String[] ids = splits[1].split(",");
-                        file.addAttribute(splits[0], ids[numAllele]);
-                        break;
                     case "AC":
                         String[] counts = splits[1].split(",");
                         file.addAttribute(splits[0], counts[numAllele]);
@@ -362,22 +357,22 @@ public class VariantVcfFactory {
     protected void checkVariantInformation(Variant variant, String fileId, String studyId)
             throws NonVariantException, IncompleteInformationException {
         VariantSourceEntry variantSourceEntry = variant.getSourceEntry(fileId, studyId);
-        if (isNonVariant(variantSourceEntry)) {
+        if (!isVariant(variantSourceEntry)) {
             throw new NonVariantException("The variant " + variant + " has no alternate allele genotype calls");
         }
     }
 
-    protected boolean isNonVariant(VariantSourceEntry variantSourceEntry){
-        boolean isNonVariant = true;
+    protected boolean isVariant(VariantSourceEntry variantSourceEntry) {
+        boolean isVariant = false;
 
         List<Map<String, String>> samplesData = variantSourceEntry.getSamplesData();
         if (!samplesData.isEmpty()) {
             if (samplesData.stream().map(m -> m.get("GT")).anyMatch(VariantVcfFactory::genotypeHasAlternateAllele)) {
-                isNonVariant = false;
+                isVariant = true;
             }
         }
 
-        return isNonVariant;
+        return isVariant;
     }
 
 

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
@@ -262,7 +262,7 @@ public class VariantVcfFactory {
     }
 
     private boolean genotypeHasAlternateAllele(String sampleField) {
-        return Arrays.stream(sampleField.split("[/|]")).anyMatch(allele -> !allele.equals("0") && !allele.equals("."));
+        return Arrays.stream(sampleField.split("[/|]")).anyMatch(allele -> allele.equals("1"));
     }
 
     protected void setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality, String filter,

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
@@ -78,9 +78,10 @@ public abstract class VariantVcfFactory {
             VariantSourceEntry file = new VariantSourceEntry(fileId, studyId, secondaryAlternates, format);
             variant.addSourceEntry(file);
 
-            parseSplitSampleData(variant, fileId, studyId, fields, alternateAlleles, secondaryAlternates, altAlleleIdx);
+            parseSplitSampleData(file, fields, altAlleleIdx);
             // Fill the rest of fields (after samples because INFO depends on them)
             setOtherFields(variant, fileId, studyId, ids, quality, filter, info, altAlleleIdx, alternateAlleles, line);
+
             checkVariantInformation(variant, fileId, studyId);
 
             variants.add(variant);
@@ -161,9 +162,8 @@ public abstract class VariantVcfFactory {
         return secondaryAlternates;
     }
 
-    protected abstract void parseSplitSampleData(Variant variant, String fileId, String studyId, String[] fields,
-                                        String[] alternateAlleles, String[] secondaryAlternates,
-                                        int alternateAlleleIdx);
+    protected abstract void parseSplitSampleData(VariantSourceEntry variantSourceEntry, String[] fields,
+                                                 int alternateAlleleIdx);
 
 
     protected void setOtherFields(Variant variant, String fileId, String studyId, Set<String> ids, float quality,

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/exception/IncompleteInformationException.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/exception/IncompleteInformationException.java
@@ -6,6 +6,6 @@ public class IncompleteInformationException extends RuntimeException {
 
     public IncompleteInformationException(Variant variant) {
         // TODO: variant to string is not defined
-        super("The variant " + variant + " has no samples data, AC and AF INFO tags");
+        super("The variant " + variant + " has no samples data, AC nor AF INFO tags");
     }
 }

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/exception/IncompleteInformationException.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/exception/IncompleteInformationException.java
@@ -5,7 +5,6 @@ import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 public class IncompleteInformationException extends RuntimeException {
 
     public IncompleteInformationException(Variant variant) {
-        // TODO: variant to string is not defined
-        super("The variant " + variant + " has no samples data, AC nor AF INFO tags");
+        super("The variant " + variant + " has no allele frequencies or counts in its INFO tag");
     }
 }

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/exception/IncompleteInformationException.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/exception/IncompleteInformationException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014-2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.ac.ebi.eva.commons.core.models.factories.exception;
 
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
@@ -5,6 +21,6 @@ import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 public class IncompleteInformationException extends RuntimeException {
 
     public IncompleteInformationException(Variant variant) {
-        super("The variant " + variant + " has no allele frequencies or counts in its INFO tag");
+        super("The variant " + variant + " has no allele frequencies or counts in its INFO column");
     }
 }

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/exception/IncompleteInformationException.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/exception/IncompleteInformationException.java
@@ -1,0 +1,10 @@
+package uk.ac.ebi.eva.commons.core.models.factories.exception;
+
+import uk.ac.ebi.eva.commons.core.models.VariantCoreFields;
+
+public class IncompleteInformationException extends RuntimeException {
+
+    public IncompleteInformationException(VariantCoreFields variant) {
+        super("The variant " + variant + " has no samples data, AC and AF INFO tags");
+    }
+}

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/exception/IncompleteInformationException.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/exception/IncompleteInformationException.java
@@ -1,10 +1,11 @@
 package uk.ac.ebi.eva.commons.core.models.factories.exception;
 
-import uk.ac.ebi.eva.commons.core.models.VariantCoreFields;
+import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 
 public class IncompleteInformationException extends RuntimeException {
 
-    public IncompleteInformationException(VariantCoreFields variant) {
+    public IncompleteInformationException(Variant variant) {
+        // TODO: variant to string is not defined
         super("The variant " + variant + " has no samples data, AC and AF INFO tags");
     }
 }

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/exception/NonVariantException.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/exception/NonVariantException.java
@@ -1,0 +1,8 @@
+package uk.ac.ebi.eva.commons.core.models.factories.exception;
+
+public class NonVariantException extends Exception {
+
+    public NonVariantException(String message) {
+        super(message);
+    }
+}

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/exception/NonVariantException.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/exception/NonVariantException.java
@@ -1,6 +1,6 @@
 package uk.ac.ebi.eva.commons.core.models.factories.exception;
 
-public class NonVariantException extends Exception {
+public class NonVariantException extends RuntimeException {
 
     public NonVariantException(String message) {
         super(message);

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/exception/NonVariantException.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/exception/NonVariantException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uk.ac.ebi.eva.commons.core.models.factories.exception;
 
 public class NonVariantException extends RuntimeException {

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactoryTest.java
@@ -190,7 +190,7 @@ public class VariantAggregatedVcfFactoryTest {
     }
 
     @Test
-    public void testVariantWitnNoAlleleCountsOrFrequency() {
+    public void testVariantWithNoAlleleCountsOrFrequency() {
         String line = "1\t1000\t.\tT\tG\t.\t.\tAA=A";
 
         thrown.expect(IncompleteInformationException.class);
@@ -198,7 +198,7 @@ public class VariantAggregatedVcfFactoryTest {
     }
 
     @Test
-    public void testMultiallelicVariantWitnNoAlleleCountsOrFrequency() {
+    public void testMultiallelicVariantWithNoAlleleCountsOrFrequency() {
         String line = "1\t1000\t.\tT\tG,A\t.\t.\tAA=A";
 
         thrown.expect(IncompleteInformationException.class);

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactoryTest.java
@@ -151,7 +151,7 @@ public class VariantAggregatedVcfFactoryTest {
 
     @Test
     public void variantWithAlleleCountZero() {
-        String line = "1\t10040\trs123\tT\tC\t.\t.\tAC=0";
+        String line = "1\t10040\trs123\tT\tC\t.\t.\tAN=5;AC=0";
 
         thrown.expect(NonVariantException.class);
         factory.create(FILE_ID, STUDY_ID, line);
@@ -167,7 +167,7 @@ public class VariantAggregatedVcfFactoryTest {
 
     @Test
     public void variantWithAlleleTotalNumberZero() {
-        String line = "1\t10040\trs123\tT\tC\t.\t.\tAN=0";
+        String line = "1\t10040\trs123\tT\tC\t.\t.\tAN=0;AC=5";
 
         thrown.expect(NonVariantException.class);
         factory.create(FILE_ID, STUDY_ID, line);

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactoryTest.java
@@ -190,7 +190,7 @@ public class VariantAggregatedVcfFactoryTest {
     }
 
     @Test
-    public void testVariantWitnNoAlleleCountsFrequencyOrSampleInformation() {
+    public void testVariantWitnNoAlleleCountsOrFrequency() {
         String line = "1\t1000\t.\tT\tG\t.\t.\tAA=A";
 
         thrown.expect(IncompleteInformationException.class);
@@ -198,7 +198,7 @@ public class VariantAggregatedVcfFactoryTest {
     }
 
     @Test
-    public void testMultiallelicVariantWitnNoAlleleCountsFrequencyOrSampleInformation() {
+    public void testMultiallelicVariantWitnNoAlleleCountsOrFrequency() {
         String line = "1\t1000\t.\tT\tG,A\t.\t.\tAA=A";
 
         thrown.expect(IncompleteInformationException.class);

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactoryTest.java
@@ -15,9 +15,13 @@
  */
 package uk.ac.ebi.eva.commons.core.models.factories;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import uk.ac.ebi.eva.commons.core.models.VariantStatistics;
+import uk.ac.ebi.eva.commons.core.models.factories.exception.IncompleteInformationException;
+import uk.ac.ebi.eva.commons.core.models.factories.exception.NonVariantException;
 import uk.ac.ebi.eva.commons.core.models.genotype.Genotype;
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 
@@ -38,6 +42,9 @@ public class VariantAggregatedVcfFactoryTest {
     private static final String STUDY_ID = "studyId";
 
     private VariantAggregatedVcfFactory factory = new VariantAggregatedVcfFactory();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void parseAC_AN() {
@@ -124,5 +131,77 @@ public class VariantAggregatedVcfFactoryTest {
         VariantAggregatedVcfFactory.getGenotype(5, alleles);    // 2/2
         assertEquals(alleles[0], alleles[1]);
         assertEquals(alleles[0], new Integer(2));
+    }
+
+    @Test
+    public void variantWithAlleleFrequencyZero() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\tAF=0";
+
+        thrown.expect(NonVariantException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void multiallelicWithAlleleFrequencyZero() {
+        String line = "1\t10040\trs123\tT\tC,G,A\t.\t.\tAF=0.5,0,0.2";
+
+        thrown.expect(NonVariantException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void variantWithAlleleCountZero() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\tAC=0";
+
+        thrown.expect(NonVariantException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void multiAlleleWithOneAlleleCountZero() {
+        String line =  "1\t10040\trs123\tT\tC,G,A\t.\t.\tAN=7;AC=5,0,2";
+
+        thrown.expect(NonVariantException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void variantWithAlleleTotalNumberZero() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\tAN=0";
+
+        thrown.expect(NonVariantException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void variantWithAlleleTotalNumberButNotAlleleCount() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\tAN=5";
+
+        thrown.expect(IncompleteInformationException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void variantWithAlleleCountButNotAlleleTotalNumber() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\tAC=5";
+
+        thrown.expect(IncompleteInformationException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void testVariantWitnNoAlleleCountsFrequencyOrSampleInformation() {
+        String line = "1\t1000\t.\tT\tG\t.\t.\tAA=A";
+
+        thrown.expect(IncompleteInformationException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void testMultiallelicVariantWitnNoAlleleCountsFrequencyOrSampleInformation() {
+        String line = "1\t1000\t.\tT\tG,A\t.\t.\tAA=A";
+
+        thrown.expect(IncompleteInformationException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
     }
 }

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactoryTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2018 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantGenotypedVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantGenotypedVcfFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014-2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uk.ac.ebi.eva.commons.core.models.factories;
 
 import org.junit.Rule;

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantGenotypedVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantGenotypedVcfFactoryTest.java
@@ -1,0 +1,467 @@
+package uk.ac.ebi.eva.commons.core.models.factories;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import uk.ac.ebi.eva.commons.core.models.factories.exception.NonVariantException;
+import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
+import uk.ac.ebi.eva.commons.core.models.pipeline.VariantSourceEntry;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class VariantGenotypedVcfFactoryTest {
+
+    private static final String FILE_ID = "fileId";
+
+    private static final String STUDY_ID = "studyId";
+
+    private static VariantVcfFactory factory = new VariantGenotypedVcfFactory();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testCreateVariant_Samples() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\t.\tGT\t0/0\t0/1\t0/.\t./1\t1/1"; // 5 samples
+
+        // Initialize expected variants
+        Variant var0 = new Variant("1", 10041, 10041 + "C".length() - 1, "T", "C");
+        VariantSourceEntry file0 = new VariantSourceEntry(FILE_ID, STUDY_ID);
+        var0.addSourceEntry(file0);
+
+        // Initialize expected samples
+        Map<String, String> na001 = new HashMap<>();
+        na001.put("GT", "0/0");
+        Map<String, String> na002 = new HashMap<>();
+        na002.put("GT", "0/1");
+        Map<String, String> na003 = new HashMap<>();
+        na003.put("GT", "0/.");
+        Map<String, String> na004 = new HashMap<>();
+        na004.put("GT", "./1");
+        Map<String, String> na005 = new HashMap<>();
+        na005.put("GT", "1/1");
+
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na001);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na002);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na003);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na004);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na005);
+
+        // Check proper conversion of samples
+        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
+        assertEquals(1, result.size());
+
+        Variant getVar0 = result.get(0);
+        assertEquals(var0.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData(),
+                     getVar0.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData());
+    }
+
+    @Test
+    public void testCreateVariantFromVcfMultiallelicVariants_Samples() {
+        String line = "1\t123456\t.\tT\tC,G\t110\tPASS\t.\tGT:AD:DP:GQ:PL\t0/1:10,5:17:94:94,0,286\t0/2:3,8:15:43:222,0,43\t0/0:.:18:.:.\t1/2:7,6:13:99:162,0,180"; // 4 samples
+
+        // Initialize expected variants
+        Variant var0 = new Variant("1", 123456, 123456, "T", "C");
+        VariantSourceEntry file0 = new VariantSourceEntry(FILE_ID, STUDY_ID);
+        var0.addSourceEntry(file0);
+
+        Variant var1 = new Variant("1", 123456, 123456, "T", "G");
+        VariantSourceEntry file1 = new VariantSourceEntry(FILE_ID, STUDY_ID);
+        var1.addSourceEntry(file1);
+
+
+        // Initialize expected samples in variant 1 (alt allele C)
+        Map<String, String> na001_C = new HashMap<>();
+        na001_C.put("GT", "0/1");
+        na001_C.put("AD", "10,5");
+        na001_C.put("DP", "17");
+        na001_C.put("GQ", "94");
+        na001_C.put("PL", "94,0,286");
+        Map<String, String> na002_C = new HashMap<>();
+        na002_C.put("GT", "0/2");
+        na002_C.put("AD", "3,8");
+        na002_C.put("DP", "15");
+        na002_C.put("GQ", "43");
+        na002_C.put("PL", "222,0,43");
+        Map<String, String> na003_C = new HashMap<>();
+        na003_C.put("GT", "0/0");
+        na003_C.put("AD", ".");
+        na003_C.put("DP", "18");
+        na003_C.put("GQ", ".");
+        na003_C.put("PL", ".");
+        Map<String, String> na004_C = new HashMap<>();
+        na004_C.put("GT", "1/2");
+        na004_C.put("AD", "7,6");
+        na004_C.put("DP", "13");
+        na004_C.put("GQ", "99");
+        na004_C.put("PL", "162,0,180");
+
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na001_C);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na002_C);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na003_C);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na004_C);
+
+        // Initialize expected samples in variant 2 (alt allele G)
+        Map<String, String> na001_G = new HashMap<>();
+        na001_G.put("GT", "0/2");
+        na001_G.put("AD", "10,5");
+        na001_G.put("DP", "17");
+        na001_G.put("GQ", "94");
+        na001_G.put("PL", "94,0,286");
+        Map<String, String> na002_G = new HashMap<>();
+        na002_G.put("GT", "0/1");
+        na002_G.put("AD", "3,8");
+        na002_G.put("DP", "15");
+        na002_G.put("GQ", "43");
+        na002_G.put("PL", "222,0,43");
+        Map<String, String> na003_G = new HashMap<>();
+        na003_G.put("GT", "0/0");
+        na003_G.put("AD", ".");
+        na003_G.put("DP", "18");
+        na003_G.put("GQ", ".");
+        na003_G.put("PL", ".");
+        Map<String, String> na004_G = new HashMap<>();
+        na004_G.put("GT", "2/1");
+        na004_G.put("AD", "7,6");
+        na004_G.put("DP", "13");
+        na004_G.put("GQ", "99");
+        na004_G.put("PL", "162,0,180");
+        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na001_G);
+        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na002_G);
+        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na003_G);
+        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na004_G);
+
+
+        // Check proper conversion of samples and alternate alleles
+        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
+        assertEquals(2, result.size());
+
+        Variant getVar0 = result.get(0);
+        assertEquals(
+                var0.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData(),
+                getVar0.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData());
+        assertArrayEquals(new String[]{"G"}, getVar0.getSourceEntry(FILE_ID, STUDY_ID).getSecondaryAlternates());
+
+        Variant getVar1 = result.get(1);
+        assertEquals(
+                var1.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData(),
+                getVar1.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData());
+        assertArrayEquals(new String[]{"C"}, getVar1.getSourceEntry(FILE_ID, STUDY_ID).getSecondaryAlternates());
+    }
+
+    @Test
+    public void testCreateVariantFromVcfCoLocatedVariants_Samples() {
+        String line = "1\t10040\trs123\tT\tC,GC\t.\t.\t.\tGT\t0/0\t0/1\t0/2\t1/1\t1/2\t2/2"; // 6 samples
+
+        // Initialize expected variants
+        Variant var0 = new Variant("1", 10041, 10041 + "C".length() - 1, "T", "C");
+        VariantSourceEntry file0 = new VariantSourceEntry(FILE_ID, STUDY_ID);
+        var0.addSourceEntry(file0);
+
+        Variant var1 = new Variant("1", 10050, 10050 + "GC".length() - 1, "T", "GC");
+        VariantSourceEntry file1 = new VariantSourceEntry(FILE_ID, STUDY_ID);
+        var1.addSourceEntry(file1);
+
+        // Initialize expected samples in variant 1 (alt allele C)
+        Map<String, String> na001_C = new HashMap<>();
+        na001_C.put("GT", "0/0");
+        Map<String, String> na002_C = new HashMap<>();
+        na002_C.put("GT", "0/1");
+        Map<String, String> na003_C = new HashMap<>();
+        na003_C.put("GT", "0/2");
+        Map<String, String> na004_C = new HashMap<>();
+        na004_C.put("GT", "1/1");
+        Map<String, String> na005_C = new HashMap<>();
+        na005_C.put("GT", "1/2");
+        Map<String, String> na006_C = new HashMap<>();
+        na006_C.put("GT", "2/2");
+
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na001_C);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na002_C);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na003_C);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na004_C);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na005_C);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na006_C);
+
+        // Initialize expected samples in variant 2 (alt allele GC)
+        Map<String, String> na001_GC = new HashMap<>();
+        na001_GC.put("GT", "0/0");
+        Map<String, String> na002_GC = new HashMap<>();
+        na002_GC.put("GT", "0/2");
+        Map<String, String> na003_GC = new HashMap<>();
+        na003_GC.put("GT", "0/1");
+        Map<String, String> na004_GC = new HashMap<>();
+        na004_GC.put("GT", "2/2");
+        Map<String, String> na005_GC = new HashMap<>();
+        na005_GC.put("GT", "2/1");
+        Map<String, String> na006_GC = new HashMap<>();
+        na006_GC.put("GT", "1/1");
+
+        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na001_GC);
+        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na002_GC);
+        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na003_GC);
+        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na004_GC);
+        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na005_GC);
+        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na006_GC);
+
+        // Check proper conversion of samples
+        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
+        assertEquals(2, result.size());
+
+        Variant getVar0 = result.get(0);
+        assertEquals(
+                var0.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData(),
+                getVar0.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData());
+        assertArrayEquals(new String[]{"GC"},
+                          getVar0.getSourceEntry(FILE_ID, STUDY_ID).getSecondaryAlternates());
+
+        Variant getVar1 = result.get(1);
+        assertEquals(
+                var1.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData(),
+                getVar1.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData());
+        assertArrayEquals(new String[]{"C"},
+                          getVar1.getSourceEntry(FILE_ID, STUDY_ID).getSecondaryAlternates());
+    }
+
+    @Test
+    public void testCreateVariantWithMissingGenotypes() {
+        String line = "1\t1407616\t.\tC\tG\t43.74\tPASS\t.\tGT:AD:DP:GQ:PL\t./.:.:.:.:.\t1/1:0,2:2:6:71,6,0\t./.:.:.:.:.\t./.:.:.:.:.";
+
+        // Initialize expected variants
+        Variant var0 = new Variant("1", 1407616, 1407616, "C", "G");
+        VariantSourceEntry file0 = new VariantSourceEntry(FILE_ID, STUDY_ID);
+        var0.addSourceEntry(file0);
+
+        // Initialize expected samples
+        Map<String, String> na001 = new HashMap<>();
+        na001.put("GT", "./.");
+        na001.put("AD", ".");
+        na001.put("DP", ".");
+        na001.put("GQ", ".");
+        na001.put("PL", ".");
+        Map<String, String> na002 = new HashMap<>();
+        na002.put("GT", "1/1");
+        na002.put("AD", "0,2");
+        na002.put("DP", "2");
+        na002.put("GQ", "6");
+        na002.put("PL", "71,6,0");
+        Map<String, String> na003 = new HashMap<>();
+        na003.put("GT", "./.");
+        na003.put("AD", ".");
+        na003.put("DP", ".");
+        na003.put("GQ", ".");
+        na003.put("PL", ".");
+        Map<String, String> na004 = new HashMap<>();
+        na004.put("GT", "./.");
+        na004.put("AD", ".");
+        na004.put("DP", ".");
+        na004.put("GQ", ".");
+        na004.put("PL", ".");
+
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na001);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na002);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na003);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na004);
+
+
+        // Check proper conversion of samples
+        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
+        assertEquals(1, result.size());
+
+        Variant getVar0 = result.get(0);
+        VariantSourceEntry getFile0 = getVar0.getSourceEntry(FILE_ID, STUDY_ID);
+
+        Map<String, String> na001Data = getFile0.getSampleData(0);
+        assertEquals("./.", na001Data.get("GT"));
+        assertEquals(".", na001Data.get("AD"));
+        assertEquals(".", na001Data.get("DP"));
+        assertEquals(".", na001Data.get("GQ"));
+        assertEquals(".", na001Data.get("PL"));
+
+        Map<String, String> na002Data = getFile0.getSampleData(1);
+        assertEquals("1/1", na002Data.get("GT"));
+        assertEquals("0,2", na002Data.get("AD"));
+        assertEquals("2", na002Data.get("DP"));
+        assertEquals("6", na002Data.get("GQ"));
+        assertEquals("71,6,0", na002Data.get("PL"));
+
+        Map<String, String> na003Data = getFile0.getSampleData(2);
+        assertEquals("./.", na003Data.get("GT"));
+        assertEquals(".", na003Data.get("AD"));
+        assertEquals(".", na003Data.get("DP"));
+        assertEquals(".", na003Data.get("GQ"));
+        assertEquals(".", na003Data.get("PL"));
+
+        Map<String, String> na004Data = getFile0.getSampleData(3);
+        assertEquals("./.", na004Data.get("GT"));
+        assertEquals(".", na004Data.get("AD"));
+        assertEquals(".", na004Data.get("DP"));
+        assertEquals(".", na004Data.get("GQ"));
+        assertEquals(".", na004Data.get("PL"));
+    }
+
+    @Test
+    public void testParseInfo() {
+        String line = "1\t123456\t.\tT\tC,G\t110\tPASS\tAN=3;AC=1,2;AF=0.125,0.25;DP=63;NS=4;MQ=10685\tGT:AD:DP:GQ:PL\t"
+                + "0/1:10,5:17:94:94,0,286\t0/2:3,8:15:43:222,0,43\t0/0:.:18:.:.\t0/2:7,6:13:0:162,0,180"; // 4 samples
+
+        // Initialize expected variants
+        Variant var0 = new Variant("1", 123456, 123456, "T", "C");
+        VariantSourceEntry file0 = new VariantSourceEntry(FILE_ID, STUDY_ID);
+        var0.addSourceEntry(file0);
+
+        Variant var1 = new Variant("1", 123456, 123456, "T", "G");
+        VariantSourceEntry file1 = new VariantSourceEntry(FILE_ID, STUDY_ID);
+        var1.addSourceEntry(file1);
+
+
+        // Initialize expected samples
+        Map<String, String> na001 = new HashMap<>();
+        na001.put("GT", "0/1");
+        na001.put("AD", "10,5");
+        na001.put("DP", "17");
+        na001.put("GQ", "94");
+        na001.put("PL", "94,0,286");
+        Map<String, String> na002 = new HashMap<>();
+        na002.put("GT", "0/1");
+        na002.put("AD", "3,8");
+        na002.put("DP", "15");
+        na002.put("GQ", "43");
+        na002.put("PL", "222,0,43");
+        Map<String, String> na003 = new HashMap<>();
+        na003.put("GT", "0/0");
+        na003.put("AD", ".");
+        na003.put("DP", "18");
+        na003.put("GQ", ".");
+        na003.put("PL", ".");
+        Map<String, String> na004 = new HashMap<>();
+        na004.put("GT", "0/1");
+        na004.put("AD", "7,6");
+        na004.put("DP", "13");
+        na004.put("GQ", "0");
+        na004.put("PL", "162,0,180");
+
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na001);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na002);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na003);
+        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na004);
+
+        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na001);
+        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na002);
+        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na003);
+        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na004);
+
+
+        // Check proper conversion of samples
+        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
+        assertEquals(2, result.size());
+
+        Variant getVar0 = result.get(0);
+        VariantSourceEntry getFile0 = getVar0.getSourceEntry(FILE_ID, STUDY_ID);
+        assertEquals(4, Integer.parseInt(getFile0.getAttribute("NS")));
+//        assertEquals(2, Integer.parseInt(getFile0.getAttribute("AN")));
+        assertEquals(1, Integer.parseInt(getFile0.getAttribute("AC")));
+        assertEquals(0.125, Double.parseDouble(getFile0.getAttribute("AF")), 1e-8);
+        assertEquals(63, Integer.parseInt(getFile0.getAttribute("DP")));
+        assertEquals(10685, Integer.parseInt(getFile0.getAttribute("MQ")));
+        assertEquals(1, Integer.parseInt(getFile0.getAttribute("MQ0")));
+
+        Variant getVar1 = result.get(1);
+        VariantSourceEntry getFile1 = getVar1.getSourceEntry(FILE_ID, STUDY_ID);
+        assertEquals(4, Integer.parseInt(getFile1.getAttribute("NS")));
+//        assertEquals(2, Integer.parseInt(getFile1.getAttribute("AN")));
+        assertEquals(2, Integer.parseInt(getFile1.getAttribute("AC")));
+        assertEquals(0.25, Double.parseDouble(getFile1.getAttribute("AF")), 1e-8);
+        assertEquals(63, Integer.parseInt(getFile1.getAttribute("DP")));
+        assertEquals(10685, Integer.parseInt(getFile1.getAttribute("MQ")));
+        assertEquals(1, Integer.parseInt(getFile1.getAttribute("MQ0")));
+    }
+
+    @Test
+    public void testVariantWithNoSampleInformation() {
+        // a variant with frequency but no genotypes, will be valid for the VariantAggregatedVcfFactory, but not for
+        // VariantGenotypedVcfFactory, that expects to find genotypes
+        String line = "1\t1000\t.\tT\tG\t.\t.\tAF=0.5";
+
+        thrown.expect(IllegalArgumentException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void testMultiallelicVariantWitnNoSampleInformation() {
+        // a variant with frequency but no genotypes, will be valid for the VariantAggregatedVcfFactory, but not for
+        // VariantGenotypedVcfFactory, that expects to find genotypes
+        String line = "1\t1000\t.\tT\tG,C\t.\t.\tAF=0.5";
+
+        thrown.expect(IllegalArgumentException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void variantWithNoAltGenotypes() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\t.\tGT\t0/0\t0|0\t./.\t0|0\t./.";
+
+        thrown.expect(NonVariantException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void haploidVariantWithNoAltGenotypes() {
+        String line = "Y\t10040\trs123\tT\tC\t.\t.\t.\tGT\t.\t0\t0\t.";
+
+        thrown.expect(NonVariantException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void triploidVariantWithNoAltGenotypes() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\t.\tGT\t0/0/0\t0|0|0\t././.\t0|0|0\t././.";
+
+        thrown.expect(NonVariantException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void variantWhereAllGenotypesAreMissingValues() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\t.\tGT\t./.\t./.\t./.\t./.\t./.";
+
+        thrown.expect(NonVariantException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void variantWhereAllGenotypesAreReference() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\t.\tGT\t0/0\t0|0\t0/0\t0|0\t0/0";
+
+        thrown.expect(NonVariantException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void multiallelicVariantAndOneAlleleHasNoGenotypes() {
+        String line = "Y\t10040\trs123\tT\tC,G,A\t.\t.\t.\tGT\t0/0\t0/2\t./.\t2/2\t0/3\t2/3";
+
+        thrown.expect(NonVariantException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void infoAttributesWontBeValidated() {
+        List<Variant> expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1000, 1000, "T", "G"));
+        String line;
+
+        // the variant is valid if it has some alternate genotypes, even if AF, AC or AN are zero
+        line = "chr1\t1000\t.\tT\tG\t.\t.\tAF=0;AC=0;AN=0\tGT\t0/1";
+        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
+        assertEquals(expResult, result);
+    }
+
+}

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfEVSFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2018 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfExacFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfExacFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2018 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 EMBL - European Bioinformatics Institute
+ * Copyright 2018 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
@@ -646,4 +646,12 @@ public class VariantVcfFactoryTest {
         thrown.expect(NonVariantException.class);
         factory.create(FILE_ID, STUDY_ID, line);
     }
+
+    @Test
+    public void variantWithAlleleTotalNumberZero() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\tAN=0";
+
+        thrown.expect(NonVariantException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
 }

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
@@ -58,8 +58,7 @@ public class VariantVcfFactoryTest {
         // is common to all the factories. The method 'parseSplitSampleData' doesn't need to do anything
         factory = new VariantVcfFactory() {
             @Override
-            protected void parseSplitSampleData(Variant variant, String fileId, String studyId, String[] fields,
-                                                String[] alternateAlleles, String[] secondaryAlternates,
+            protected void parseSplitSampleData(VariantSourceEntry variantSourceEntry, String[] fields,
                                                 int alternateAlleleIdx) {
             }
         };

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
@@ -360,7 +360,7 @@ public class VariantVcfFactoryTest {
         var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na005_C);
         var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na006_C);
 
-        // TODO Initialize expected samples in variant 2 (alt allele GC)
+        // Initialize expected samples in variant 2 (alt allele GC)
         Map<String, String> na001_GC = new HashMap<>();
         na001_GC.put("GT", "0/0");
         Map<String, String> na002_GC = new HashMap<>();

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
@@ -629,6 +629,22 @@ public class VariantVcfFactoryTest {
     }
 
     @Test
+    public void variantWhereAllGenotypesAreMissingValues() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\t.\tGT\t./.\t./.\t./.\t./.\t./.";
+
+        thrown.expect(NonVariantException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void variantWhereAllGenotypesAreReference() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\t.\tGT\t0/0\t0|0\t0/0\t0|0\t0/0";
+
+        thrown.expect(NonVariantException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
     public void multiallelicVariantAndOneAlleleHasNoGenotypes() {
         String line = "Y\t10040\trs123\tT\tC,G,A\t.\t.\t.\tGT\t0/0\t0/2\t./.\t2/2\t0/3\t2/3";
 

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
@@ -637,4 +637,22 @@ public class VariantVcfFactoryTest {
         assertTrue(result.stream().anyMatch(v -> v.getAlternate().equals("C")));
         assertTrue(result.stream().anyMatch(v -> v.getAlternate().equals("A")));
     }
+
+    @Test
+    public void variantWithAlleleCountZeroWontBeCreatedByTheFactory() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\tAC=0";
+
+        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
+
+        assertEquals(0, result.size());
+
+        // multiallelic variant, one of the alt has AC=0
+        line = "1\t10040\trs123\tT\tC,G,A\t.\t.\tAC=0.5,0,0.2";
+
+        result = factory.create(FILE_ID, STUDY_ID, line);
+
+        assertEquals(2, result.size());
+        assertTrue(result.stream().anyMatch(v -> v.getAlternate().equals("C")));
+        assertTrue(result.stream().anyMatch(v -> v.getAlternate().equals("A")));
+    }
 }

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
@@ -56,15 +56,15 @@ public class VariantVcfFactoryTest {
         expResult.add(new Variant("1", 1000, 1000, "T", "G"));
         String line;
 
-        line = "chr1\t1000\t.\tT\tG\t.\t.\tAF=0.5";
+        line = "chr1\t1000\t.\tT\tG\t.\t.\t.\tGT\t0/1";
         List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "Chr1\t1000\t.\tT\tG\t.\t.\tAF=0.5";
+        line = "Chr1\t1000\t.\tT\tG\t.\t.\t.\tGT\t0/1";
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "CHR1\t1000\t.\tT\tG\t.\t.\tAF=0.5";
+        line = "CHR1\t1000\t.\tT\tG\t.\t.\t.\tGT\t0/1";
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
     }
@@ -72,7 +72,7 @@ public class VariantVcfFactoryTest {
     @Test
     public void testCreateVariantFromVcfSameLengthRefAlt() {
         // Test when there are differences at the end of the sequence
-        String line = "1\t1000\trs123\tTCACCC\tTGACGG\t.\t.\tAF=0.5";
+        String line = "1\t1000\trs123\tTCACCC\tTGACGG\t.\t.\t.\tGT\t0/1";
 
         List<Variant> expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1005, "CACCC", "GACGG"));
@@ -81,7 +81,7 @@ public class VariantVcfFactoryTest {
         assertEquals(expResult, result);
 
         // Test when there are not differences at the end of the sequence
-        line = "1\t1000\trs123\tTCACCC\tTGACGC\t.\t.\tAF=0.5";
+        line = "1\t1000\trs123\tTCACCC\tTGACGC\t.\t.\t.\tGT\t0/1";
 
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1004, "CACC", "GACG"));
@@ -92,7 +92,7 @@ public class VariantVcfFactoryTest {
 
     @Test
     public void testCreateVariantFromVcfInsertionEmptyRef() {
-        String line = "1\t1000\trs123\t.\tTGACGC\t.\t.\tAF=0.5";
+        String line = "1\t1000\trs123\t.\tTGACGC\t.\t.\t.\tGT\t0/1";
 
         List<Variant> expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000 + "TGACGC".length() - 1, "", "TGACGC"));
@@ -103,7 +103,7 @@ public class VariantVcfFactoryTest {
 
     @Test
     public void testCreateVariantFromVcfDeletionEmptyAlt() {
-        String line = "1\t999\trs123\tGTCACCC\tG\t.\t.\tAF=0.5";
+        String line = "1\t999\trs123\tGTCACCC\tG\t.\t.\t.\tGT\t0/1";
 
         List<Variant> expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000 + "TCACCC".length() - 1, "TCACCC", ""));
@@ -114,69 +114,69 @@ public class VariantVcfFactoryTest {
 
     @Test
     public void testCreateVariantFromVcfIndelNotEmptyFields() {
-        String line = "1\t1000\trs123\tCGATT\tTAC\t.\t.\tAF=0.5";
+        String line = "1\t1000\trs123\tCGATT\tTAC\t.\t.\t.\tGT\t0/1";
 
         List<Variant> expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000 + "CGATT".length() - 1, "CGATT", "TAC"));
         List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tAT\tA\t.\t.\tAF=0.5";
+        line = "1\t1000\trs123\tAT\tA\t.\t.\t.\tGT\t0/1";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1001, "T", ""));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tGATC\tG\t.\t.\tAF=0.5";
+        line = "1\t1000\trs123\tGATC\tG\t.\t.\t.\tGT\t0/1";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1003, "ATC", ""));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\t.\tATC\t.\t.\tAF=0.5";
+        line = "1\t1000\trs123\t.\tATC\t.\t.\t.\tGT\t0/1";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1002, "", "ATC"));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tA\tATC\t.\t.\tAF=0.5";
+        line = "1\t1000\trs123\tA\tATC\t.\t.\t.\tGT\t0/1";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1002, "", "TC"));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tAC\tACT\t.\t.\tAF=0.5";
+        line = "1\t1000\trs123\tAC\tACT\t.\t.\t.\tGT\t0/1";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1002, 1002, "", "T"));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
         // Printing those that are not currently managed
-        line = "1\t1000\trs123\tAT\tT\t.\t.\tAF=0.5";
+        line = "1\t1000\trs123\tAT\tT\t.\t.\t.\tGT\t0/1";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "A", ""));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tATC\tTC\t.\t.\tAF=0.5";
+        line = "1\t1000\trs123\tATC\tTC\t.\t.\t.\tGT\t0/1";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "A", ""));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tATC\tAC\t.\t.\tAF=0.5";
+        line = "1\t1000\trs123\tATC\tAC\t.\t.\t.\tGT\t0/1";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1001, "T", ""));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tAC\tATC\t.\t.\tAF=0.5";
+        line = "1\t1000\trs123\tAC\tATC\t.\t.\t.\tGT\t0/1";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1001, "", "T"));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tATC\tGC\t.\t.\tAF=0.5";
+        line = "1\t1000\trs123\tATC\tGC\t.\t.\t.\tGT\t0/1";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1001, "AT", "G"));
         result = factory.create(FILE_ID, STUDY_ID, line);
@@ -559,7 +559,7 @@ public class VariantVcfFactoryTest {
 
         Set<String> emptySet = new HashSet<>();
         // test that an ID is properly handled
-        String line = "1\t1000\trs123\tC\tT\t.\t.\tAF=0.5";
+        String line = "1\t1000\trs123\tC\tT\t.\t.\t.\tGT\t0/1";
         List<Variant> expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "C", "T"));
         List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
@@ -568,7 +568,7 @@ public class VariantVcfFactoryTest {
         assertEquals(emptySet, result.get(0).getIds());
 
         // test that the ';' is used as the ID separator (as of VCF 4.2)
-        line = "1\t1000\trs123;rs456\tC\tT\t.\t.\tAF=0.5";
+        line = "1\t1000\trs123;rs456\tC\tT\t.\t.\t.\tGT\t0/1";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "C", "T"));
         result = factory.create(FILE_ID, STUDY_ID, line);
@@ -576,7 +576,7 @@ public class VariantVcfFactoryTest {
         assertEquals(emptySet, result.get(0).getIds());
 
         // test that a missing ID ('.') is not added to the IDs set
-        line = "1\t1000\t.\tC\tT\t.\t.\tAF=0.5";
+        line = "1\t1000\t.\tC\tT\t.\t.\t.\tGT\t0/1";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "C", "T"));
         result = factory.create(FILE_ID, STUDY_ID, line);
@@ -585,34 +585,22 @@ public class VariantVcfFactoryTest {
     }
 
     @Test
-    public void testVariantWitnNoInfoOrSampleInformation() {
-        String line = "1\t1000\t.\tT\tG\t.\t.\t.";
+    public void testVariantWitnNoSampleInformation() {
+        // a variant with frequency but no genotypes, will be valid for the VariantAggregatedVcfFactory, but not a
+        // variant for VariantVcfFactory, that expects to find genotypes
+        String line = "1\t1000\t.\tT\tG\t.\t.\tAF=0.5";
 
-        thrown.expect(IncompleteInformationException.class);
+        thrown.expect(NonVariantException.class);
         factory.create(FILE_ID, STUDY_ID, line);
     }
 
     @Test
-    public void testMultiallelicVariantWitnNoInfoOrSampleInformation() {
-        String line = "1\t1000\t.\tT\tG,C\t.\t.\t.";
+    public void testMultiallelicVariantWitnNoSampleInformation() {
+        // a variant with frequency but no genotypes, will be valid for the VariantAggregatedVcfFactory, but not a
+        // variant for VariantVcfFactory, that expects to find genotypes
+        String line = "1\t1000\t.\tT\tG,C\t.\t.\tAF=0.5";
 
-        thrown.expect(IncompleteInformationException.class);
-        factory.create(FILE_ID, STUDY_ID, line);
-    }
-
-    @Test
-    public void testVariantWitnNoAlleleCountsFrequencyOrSampleInformation() {
-        String line = "1\t1000\t.\tT\tG\t.\t.\tAA=A";
-
-        thrown.expect(IncompleteInformationException.class);
-        factory.create(FILE_ID, STUDY_ID, line);
-    }
-
-    @Test
-    public void testMultiallelicVariantWitnNoAlleleCountsFrequencyOrSampleInformation() {
-        String line = "1\t1000\t.\tT\tG,A\t.\t.\tAA=A";
-
-        thrown.expect(IncompleteInformationException.class);
+        thrown.expect(NonVariantException.class);
         factory.create(FILE_ID, STUDY_ID, line);
     }
 
@@ -649,58 +637,14 @@ public class VariantVcfFactoryTest {
     }
 
     @Test
-    public void variantWithAlleleFrequencyZero() {
-        String line = "1\t10040\trs123\tT\tC\t.\t.\tAF=0";
+    public void infoAttributesWontBeValidated() {
+        List<Variant> expResult = new LinkedList<>();
+        expResult.add(new Variant("1", 1000, 1000, "T", "G"));
+        String line;
 
-        thrown.expect(NonVariantException.class);
-        factory.create(FILE_ID, STUDY_ID, line);
-    }
-
-    @Test
-    public void multiallelicWithAlleleFrequencyZero() {
-        String line = "1\t10040\trs123\tT\tC,G,A\t.\t.\tAF=0.5,0,0.2";
-
-        thrown.expect(NonVariantException.class);
-        factory.create(FILE_ID, STUDY_ID, line);
-    }
-
-    @Test
-    public void variantWithAlleleCountZero() {
-        String line = "1\t10040\trs123\tT\tC\t.\t.\tAC=0";
-
-        thrown.expect(NonVariantException.class);
-        factory.create(FILE_ID, STUDY_ID, line);
-    }
-
-    @Test
-    public void multiAlleleWithOneAlleleCountZero() {
-        String line =  "1\t10040\trs123\tT\tC,G,A\t.\t.\tAN=7;AC=5,0,2";
-
-        thrown.expect(NonVariantException.class);
-        factory.create(FILE_ID, STUDY_ID, line);
-    }
-
-    @Test
-    public void variantWithAlleleTotalNumberZero() {
-        String line = "1\t10040\trs123\tT\tC\t.\t.\tAN=0";
-
-        thrown.expect(NonVariantException.class);
-        factory.create(FILE_ID, STUDY_ID, line);
-    }
-
-    @Test
-    public void variantWithAlleleTotalNumberButNotAlleleCount() {
-        String line = "1\t10040\trs123\tT\tC\t.\t.\tAN=5";
-
-        thrown.expect(IncompleteInformationException.class);
-        factory.create(FILE_ID, STUDY_ID, line);
-    }
-
-    @Test
-    public void variantWithAlleleCountButNotAlleleTotalNumber() {
-        String line = "1\t10040\trs123\tT\tC\t.\t.\tAC=5";
-
-        thrown.expect(IncompleteInformationException.class);
-        factory.create(FILE_ID, STUDY_ID, line);
+        // the variant is valid if it has some alternate genotypes, even if AF, AC or AN are zero
+        line = "chr1\t1000\t.\tT\tG\t.\t.\tAF=0;AC=0;AN=0\tGT\t0/1";
+        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
+        assertEquals(expResult, result);
     }
 }

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
@@ -578,4 +578,35 @@ public class VariantVcfFactoryTest {
         assertEquals(expResult, result);
         assertEquals(emptySet, result.get(0).getIds());
     }
+
+    @Test
+    public void variantWithAllGenotypesNoAltWontBeCreatedByTheFactory() {
+        // diploid calls
+        String line = "1\t10040\trs123\tT\tC\t.\t.\t.\tGT\t0/0\t0|0\t./.\t0|0\t./.";
+
+        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
+
+        assertEquals(0, result.size());
+
+        // haploid calls
+        line = "Y\t10040\trs123\tT\tC\t.\t.\t.\tGT\t.\t0\t0\t.";
+
+        result = factory.create(FILE_ID, STUDY_ID, line);
+
+        assertEquals(0, result.size());
+
+        // triploid calls
+        line = "1\t10040\trs123\tT\tC\t.\t.\t.\tGT\t0/0/0\t0|0|0\t././.\t0|0|0\t././.";
+
+        result = factory.create(FILE_ID, STUDY_ID, line);
+
+        assertEquals(0, result.size());
+
+        // a variant with no genotypes won't be discarded
+        line = "1\t10040\trs123\tT\tC\t.\t.\t.";
+
+        result = factory.create(FILE_ID, STUDY_ID, line);
+
+        assertEquals(1, result.size());
+    }
 }

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
@@ -19,6 +19,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import uk.ac.ebi.eva.commons.core.models.factories.exception.IncompleteInformationException;
 import uk.ac.ebi.eva.commons.core.models.factories.exception.NonVariantException;
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 import uk.ac.ebi.eva.commons.core.models.pipeline.VariantSourceEntry;
@@ -55,15 +56,15 @@ public class VariantVcfFactoryTest {
         expResult.add(new Variant("1", 1000, 1000, "T", "G"));
         String line;
 
-        line = "chr1\t1000\t.\tT\tG\t.\t.\t.";
+        line = "chr1\t1000\t.\tT\tG\t.\t.\tAF=0.5";
         List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "Chr1\t1000\t.\tT\tG\t.\t.\t.";
+        line = "Chr1\t1000\t.\tT\tG\t.\t.\tAF=0.5";
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "CHR1\t1000\t.\tT\tG\t.\t.\t.";
+        line = "CHR1\t1000\t.\tT\tG\t.\t.\tAF=0.5";
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
     }
@@ -71,7 +72,7 @@ public class VariantVcfFactoryTest {
     @Test
     public void testCreateVariantFromVcfSameLengthRefAlt() {
         // Test when there are differences at the end of the sequence
-        String line = "1\t1000\trs123\tTCACCC\tTGACGG\t.\t.\t.";
+        String line = "1\t1000\trs123\tTCACCC\tTGACGG\t.\t.\tAF=0.5";
 
         List<Variant> expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1005, "CACCC", "GACGG"));
@@ -80,7 +81,7 @@ public class VariantVcfFactoryTest {
         assertEquals(expResult, result);
 
         // Test when there are not differences at the end of the sequence
-        line = "1\t1000\trs123\tTCACCC\tTGACGC\t.\t.\t.";
+        line = "1\t1000\trs123\tTCACCC\tTGACGC\t.\t.\tAF=0.5";
 
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1004, "CACC", "GACG"));
@@ -91,7 +92,7 @@ public class VariantVcfFactoryTest {
 
     @Test
     public void testCreateVariantFromVcfInsertionEmptyRef() {
-        String line = "1\t1000\trs123\t.\tTGACGC\t.\t.\t.";
+        String line = "1\t1000\trs123\t.\tTGACGC\t.\t.\tAF=0.5";
 
         List<Variant> expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000 + "TGACGC".length() - 1, "", "TGACGC"));
@@ -102,7 +103,7 @@ public class VariantVcfFactoryTest {
 
     @Test
     public void testCreateVariantFromVcfDeletionEmptyAlt() {
-        String line = "1\t999\trs123\tGTCACCC\tG\t.\t.\t.";
+        String line = "1\t999\trs123\tGTCACCC\tG\t.\t.\tAF=0.5";
 
         List<Variant> expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000 + "TCACCC".length() - 1, "TCACCC", ""));
@@ -113,69 +114,69 @@ public class VariantVcfFactoryTest {
 
     @Test
     public void testCreateVariantFromVcfIndelNotEmptyFields() {
-        String line = "1\t1000\trs123\tCGATT\tTAC\t.\t.\t.";
+        String line = "1\t1000\trs123\tCGATT\tTAC\t.\t.\tAF=0.5";
 
         List<Variant> expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000 + "CGATT".length() - 1, "CGATT", "TAC"));
         List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tAT\tA\t.\t.\t.";
+        line = "1\t1000\trs123\tAT\tA\t.\t.\tAF=0.5";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1001, "T", ""));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tGATC\tG\t.\t.\t.";
+        line = "1\t1000\trs123\tGATC\tG\t.\t.\tAF=0.5";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1003, "ATC", ""));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\t.\tATC\t.\t.\t.";
+        line = "1\t1000\trs123\t.\tATC\t.\t.\tAF=0.5";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1002, "", "ATC"));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tA\tATC\t.\t.\t.";
+        line = "1\t1000\trs123\tA\tATC\t.\t.\tAF=0.5";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1002, "", "TC"));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tAC\tACT\t.\t.\t.";
+        line = "1\t1000\trs123\tAC\tACT\t.\t.\tAF=0.5";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1002, 1002, "", "T"));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
         // Printing those that are not currently managed
-        line = "1\t1000\trs123\tAT\tT\t.\t.\t.";
+        line = "1\t1000\trs123\tAT\tT\t.\t.\tAF=0.5";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "A", ""));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tATC\tTC\t.\t.\t.";
+        line = "1\t1000\trs123\tATC\tTC\t.\t.\tAF=0.5";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "A", ""));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tATC\tAC\t.\t.\t.";
+        line = "1\t1000\trs123\tATC\tAC\t.\t.\tAF=0.5";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1001, "T", ""));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tAC\tATC\t.\t.\t.";
+        line = "1\t1000\trs123\tAC\tATC\t.\t.\tAF=0.5";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1001, "", "T"));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tATC\tGC\t.\t.\t.";
+        line = "1\t1000\trs123\tATC\tGC\t.\t.\tAF=0.5";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1001, "AT", "G"));
         result = factory.create(FILE_ID, STUDY_ID, line);
@@ -558,7 +559,7 @@ public class VariantVcfFactoryTest {
 
         Set<String> emptySet = new HashSet<>();
         // test that an ID is properly handled
-        String line = "1\t1000\trs123\tC\tT\t.\t.\t.";
+        String line = "1\t1000\trs123\tC\tT\t.\t.\tAF=0.5";
         List<Variant> expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "C", "T"));
         List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
@@ -567,7 +568,7 @@ public class VariantVcfFactoryTest {
         assertEquals(emptySet, result.get(0).getIds());
 
         // test that the ';' is used as the ID separator (as of VCF 4.2)
-        line = "1\t1000\trs123;rs456\tC\tT\t.\t.\t.";
+        line = "1\t1000\trs123;rs456\tC\tT\t.\t.\tAF=0.5";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "C", "T"));
         result = factory.create(FILE_ID, STUDY_ID, line);
@@ -575,12 +576,44 @@ public class VariantVcfFactoryTest {
         assertEquals(emptySet, result.get(0).getIds());
 
         // test that a missing ID ('.') is not added to the IDs set
-        line = "1\t1000\t.\tC\tT\t.\t.\t.";
+        line = "1\t1000\t.\tC\tT\t.\t.\tAF=0.5";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "C", "T"));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
         assertEquals(emptySet, result.get(0).getIds());
+    }
+
+    @Test
+    public void testVariantWitnNoInfoOrSampleInformation() {
+        String line = "1\t1000\t.\tT\tG\t.\t.\t.";
+
+        thrown.expect(IncompleteInformationException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void testMultiallelicVariantWitnNoInfoOrSampleInformation() {
+        String line = "1\t1000\t.\tT\tG,C\t.\t.\t.";
+
+        thrown.expect(IncompleteInformationException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void testVariantWitnNoAlleleCountsFrequencyOrSampleInformation() {
+        String line = "1\t1000\t.\tT\tG\t.\t.\tAA=A";
+
+        thrown.expect(IncompleteInformationException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void testMultiallelicVariantWitnNoAlleleCountsFrequencyOrSampleInformation() {
+        String line = "1\t1000\t.\tT\tG,A\t.\t.\tAA=A";
+
+        thrown.expect(IncompleteInformationException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
     }
 
     @Test
@@ -608,7 +641,7 @@ public class VariantVcfFactoryTest {
     }
 
     @Test
-    public void multiAllelicVariantAndOneAlleleHasNoGenotypes() {
+    public void multiallelicVariantAndOneAlleleHasNoGenotypes() {
         String line = "Y\t10040\trs123\tT\tC,G,A\t.\t.\t.\tGT\t0/0\t0/2\t./.\t2/2\t0/3\t2/3";
 
         thrown.expect(NonVariantException.class);
@@ -624,7 +657,7 @@ public class VariantVcfFactoryTest {
     }
 
     @Test
-    public void multiAllelicWithAlleleFrequencyZero() {
+    public void multiallelicWithAlleleFrequencyZero() {
         String line = "1\t10040\trs123\tT\tC,G,A\t.\t.\tAF=0.5,0,0.2";
 
         thrown.expect(NonVariantException.class);

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -180,7 +181,7 @@ public class VariantVcfFactoryTest {
 
     @Test
     public void testCreateVariantFromVcfCoLocatedVariants_MainFields() {
-        String line = "1\t10040\trs123\tTGACGTAACGATT\tT,TGACGTAACGGTT,TGACGTAATAC\t.\t.\t.\tGT\t0/0\t0/1\t0/2\t1/2"; // 4 samples
+        String line = "1\t10040\trs123\tTGACGTAACGATT\tT,TGACGTAACGGTT,TGACGTAATAC\t.\t.\t.\tGT\t0/0\t0/1\t0/2\t1/3"; // 4 samples
 
         // Check proper conversion of main fields
         List<Variant> expResult = new LinkedList<>();
@@ -608,5 +609,14 @@ public class VariantVcfFactoryTest {
         result = factory.create(FILE_ID, STUDY_ID, line);
 
         assertEquals(1, result.size());
+
+        // multiallelic variant, one of the alt has no calls
+        line = "Y\t10040\trs123\tT\tC,G,A\t.\t.\t.\tGT\t0/0\t0/2\t./.\t2/2\t0/3\t2/3";
+
+        result = factory.create(FILE_ID, STUDY_ID, line);
+
+        assertEquals(2, result.size());
+        assertTrue(result.stream().anyMatch(v -> v.getAlternate().equals("G")));
+        assertTrue(result.stream().anyMatch(v -> v.getAlternate().equals("A")));
     }
 }

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
@@ -674,7 +674,7 @@ public class VariantVcfFactoryTest {
 
     @Test
     public void multiAlleleWithOneAlleleCountZero() {
-        String line =  "1\t10040\trs123\tT\tC,G,A\t.\t.\tAC=0.5,0,0.2";
+        String line =  "1\t10040\trs123\tT\tC,G,A\t.\t.\tAN=7;AC=5,0,2";
 
         thrown.expect(NonVariantException.class);
         factory.create(FILE_ID, STUDY_ID, line);
@@ -685,6 +685,22 @@ public class VariantVcfFactoryTest {
         String line = "1\t10040\trs123\tT\tC\t.\t.\tAN=0";
 
         thrown.expect(NonVariantException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void variantWithAlleleTotalNumberButNotAlleleCount() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\tAN=5";
+
+        thrown.expect(IncompleteInformationException.class);
+        factory.create(FILE_ID, STUDY_ID, line);
+    }
+
+    @Test
+    public void variantWithAlleleCountButNotAlleleTotalNumber() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\tAC=5";
+
+        thrown.expect(IncompleteInformationException.class);
         factory.create(FILE_ID, STUDY_ID, line);
     }
 }

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
@@ -619,4 +619,22 @@ public class VariantVcfFactoryTest {
         assertTrue(result.stream().anyMatch(v -> v.getAlternate().equals("G")));
         assertTrue(result.stream().anyMatch(v -> v.getAlternate().equals("A")));
     }
+
+    @Test
+    public void variantWithAlleleFrequencyZeroWontBeCreatedByTheFactory() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\tAF=0";
+
+        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
+
+        assertEquals(0, result.size());
+
+        // multiallelic variant, one of the alt has AF=0
+        line = "1\t10040\trs123\tT\tC,G,A\t.\t.\tAF=0.5,0,0.2";
+
+        result = factory.create(FILE_ID, STUDY_ID, line);
+
+        assertEquals(2, result.size());
+        assertTrue(result.stream().anyMatch(v -> v.getAlternate().equals("C")));
+        assertTrue(result.stream().anyMatch(v -> v.getAlternate().equals("A")));
+    }
 }

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
@@ -585,7 +585,7 @@ public class VariantVcfFactoryTest {
     }
 
     @Test
-    public void testVariantWitnNoSampleInformation() {
+    public void testVariantWithNoSampleInformation() {
         // a variant with frequency but no genotypes, will be valid for the VariantAggregatedVcfFactory, but not a
         // variant for VariantVcfFactory, that expects to find genotypes
         String line = "1\t1000\t.\tT\tG\t.\t.\tAF=0.5";

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactoryTest.java
@@ -15,6 +15,8 @@
  */
 package uk.ac.ebi.eva.commons.core.models.factories;
 
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -45,10 +47,23 @@ public class VariantVcfFactoryTest {
 
     private static final String STUDY_ID = "studyId";
 
-    private VariantVcfFactory factory = new VariantVcfFactory();
+    private static VariantVcfFactory factory;
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+
+    @BeforeClass
+    public static void setupClass() {
+        // create an object of the abstract class VariantVcfFactory to test the code to parse the basic VCF fields, that
+        // is common to all the factories. The method 'parseSplitSampleData' doesn't need to do anything
+        factory = new VariantVcfFactory() {
+            @Override
+            protected void parseSplitSampleData(Variant variant, String fileId, String studyId, String[] fields,
+                                                String[] alternateAlleles, String[] secondaryAlternates,
+                                                int alternateAlleleIdx) {
+            }
+        };
+    }
 
     @Test
     public void testRemoveChrPrefixInAnyCase() {
@@ -56,15 +71,15 @@ public class VariantVcfFactoryTest {
         expResult.add(new Variant("1", 1000, 1000, "T", "G"));
         String line;
 
-        line = "chr1\t1000\t.\tT\tG\t.\t.\t.\tGT\t0/1";
+        line = "chr1\t1000\t.\tT\tG\t.\t.\t.";
         List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "Chr1\t1000\t.\tT\tG\t.\t.\t.\tGT\t0/1";
+        line = "Chr1\t1000\t.\tT\tG\t.\t.\t.";
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "CHR1\t1000\t.\tT\tG\t.\t.\t.\tGT\t0/1";
+        line = "CHR1\t1000\t.\tT\tG\t.\t.\t.";
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
     }
@@ -72,7 +87,7 @@ public class VariantVcfFactoryTest {
     @Test
     public void testCreateVariantFromVcfSameLengthRefAlt() {
         // Test when there are differences at the end of the sequence
-        String line = "1\t1000\trs123\tTCACCC\tTGACGG\t.\t.\t.\tGT\t0/1";
+        String line = "1\t1000\trs123\tTCACCC\tTGACGG\t.\t.\t.";
 
         List<Variant> expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1005, "CACCC", "GACGG"));
@@ -81,7 +96,7 @@ public class VariantVcfFactoryTest {
         assertEquals(expResult, result);
 
         // Test when there are not differences at the end of the sequence
-        line = "1\t1000\trs123\tTCACCC\tTGACGC\t.\t.\t.\tGT\t0/1";
+        line = "1\t1000\trs123\tTCACCC\tTGACGC\t.\t.\t.";
 
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1004, "CACC", "GACG"));
@@ -92,7 +107,7 @@ public class VariantVcfFactoryTest {
 
     @Test
     public void testCreateVariantFromVcfInsertionEmptyRef() {
-        String line = "1\t1000\trs123\t.\tTGACGC\t.\t.\t.\tGT\t0/1";
+        String line = "1\t1000\trs123\t.\tTGACGC\t.\t.\t.";
 
         List<Variant> expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000 + "TGACGC".length() - 1, "", "TGACGC"));
@@ -103,7 +118,7 @@ public class VariantVcfFactoryTest {
 
     @Test
     public void testCreateVariantFromVcfDeletionEmptyAlt() {
-        String line = "1\t999\trs123\tGTCACCC\tG\t.\t.\t.\tGT\t0/1";
+        String line = "1\t999\trs123\tGTCACCC\tG\t.\t.\t.";
 
         List<Variant> expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000 + "TCACCC".length() - 1, "TCACCC", ""));
@@ -114,69 +129,69 @@ public class VariantVcfFactoryTest {
 
     @Test
     public void testCreateVariantFromVcfIndelNotEmptyFields() {
-        String line = "1\t1000\trs123\tCGATT\tTAC\t.\t.\t.\tGT\t0/1";
+        String line = "1\t1000\trs123\tCGATT\tTAC\t.\t.\t.";
 
         List<Variant> expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000 + "CGATT".length() - 1, "CGATT", "TAC"));
         List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tAT\tA\t.\t.\t.\tGT\t0/1";
+        line = "1\t1000\trs123\tAT\tA\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1001, "T", ""));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tGATC\tG\t.\t.\t.\tGT\t0/1";
+        line = "1\t1000\trs123\tGATC\tG\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1003, "ATC", ""));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\t.\tATC\t.\t.\t.\tGT\t0/1";
+        line = "1\t1000\trs123\t.\tATC\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1002, "", "ATC"));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tA\tATC\t.\t.\t.\tGT\t0/1";
+        line = "1\t1000\trs123\tA\tATC\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1002, "", "TC"));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tAC\tACT\t.\t.\t.\tGT\t0/1";
+        line = "1\t1000\trs123\tAC\tACT\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1002, 1002, "", "T"));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
         // Printing those that are not currently managed
-        line = "1\t1000\trs123\tAT\tT\t.\t.\t.\tGT\t0/1";
+        line = "1\t1000\trs123\tAT\tT\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "A", ""));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tATC\tTC\t.\t.\t.\tGT\t0/1";
+        line = "1\t1000\trs123\tATC\tTC\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "A", ""));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tATC\tAC\t.\t.\t.\tGT\t0/1";
+        line = "1\t1000\trs123\tATC\tAC\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1001, "T", ""));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tAC\tATC\t.\t.\t.\tGT\t0/1";
+        line = "1\t1000\trs123\tAC\tATC\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1001, 1001, "", "T"));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
 
-        line = "1\t1000\trs123\tATC\tGC\t.\t.\t.\tGT\t0/1";
+        line = "1\t1000\trs123\tATC\tGC\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1001, "AT", "G"));
         result = factory.create(FILE_ID, STUDY_ID, line);
@@ -198,368 +213,11 @@ public class VariantVcfFactoryTest {
     }
 
     @Test
-    public void testCreateVariant_Samples() {
-        String line = "1\t10040\trs123\tT\tC\t.\t.\t.\tGT\t0/0\t0/1\t0/.\t./1\t1/1"; // 5 samples
-
-        // Initialize expected variants
-        Variant var0 = new Variant("1", 10041, 10041 + "C".length() - 1, "T", "C");
-        VariantSourceEntry file0 = new VariantSourceEntry(FILE_ID, STUDY_ID);
-        var0.addSourceEntry(file0);
-
-        // Initialize expected samples
-        Map<String, String> na001 = new HashMap<>();
-        na001.put("GT", "0/0");
-        Map<String, String> na002 = new HashMap<>();
-        na002.put("GT", "0/1");
-        Map<String, String> na003 = new HashMap<>();
-        na003.put("GT", "0/.");
-        Map<String, String> na004 = new HashMap<>();
-        na004.put("GT", "./1");
-        Map<String, String> na005 = new HashMap<>();
-        na005.put("GT", "1/1");
-
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na001);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na002);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na003);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na004);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na005);
-
-        // Check proper conversion of samples
-        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
-        assertEquals(1, result.size());
-
-        Variant getVar0 = result.get(0);
-        assertEquals(var0.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData(),
-                     getVar0.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData());
-    }
-
-    @Test
-    public void testCreateVariantFromVcfMultiallelicVariants_Samples() {
-        String line = "1\t123456\t.\tT\tC,G\t110\tPASS\t.\tGT:AD:DP:GQ:PL\t0/1:10,5:17:94:94,0,286\t0/2:3,8:15:43:222,0,43\t0/0:.:18:.:.\t1/2:7,6:13:99:162,0,180"; // 4 samples
-
-        // Initialize expected variants
-        Variant var0 = new Variant("1", 123456, 123456, "T", "C");
-        VariantSourceEntry file0 = new VariantSourceEntry(FILE_ID, STUDY_ID);
-        var0.addSourceEntry(file0);
-
-        Variant var1 = new Variant("1", 123456, 123456, "T", "G");
-        VariantSourceEntry file1 = new VariantSourceEntry(FILE_ID, STUDY_ID);
-        var1.addSourceEntry(file1);
-
-
-        // Initialize expected samples in variant 1 (alt allele C)
-        Map<String, String> na001_C = new HashMap<>();
-        na001_C.put("GT", "0/1");
-        na001_C.put("AD", "10,5");
-        na001_C.put("DP", "17");
-        na001_C.put("GQ", "94");
-        na001_C.put("PL", "94,0,286");
-        Map<String, String> na002_C = new HashMap<>();
-        na002_C.put("GT", "0/2");
-        na002_C.put("AD", "3,8");
-        na002_C.put("DP", "15");
-        na002_C.put("GQ", "43");
-        na002_C.put("PL", "222,0,43");
-        Map<String, String> na003_C = new HashMap<>();
-        na003_C.put("GT", "0/0");
-        na003_C.put("AD", ".");
-        na003_C.put("DP", "18");
-        na003_C.put("GQ", ".");
-        na003_C.put("PL", ".");
-        Map<String, String> na004_C = new HashMap<>();
-        na004_C.put("GT", "1/2");
-        na004_C.put("AD", "7,6");
-        na004_C.put("DP", "13");
-        na004_C.put("GQ", "99");
-        na004_C.put("PL", "162,0,180");
-
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na001_C);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na002_C);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na003_C);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na004_C);
-
-        // Initialize expected samples in variant 2 (alt allele G)
-        Map<String, String> na001_G = new HashMap<>();
-        na001_G.put("GT", "0/2");
-        na001_G.put("AD", "10,5");
-        na001_G.put("DP", "17");
-        na001_G.put("GQ", "94");
-        na001_G.put("PL", "94,0,286");
-        Map<String, String> na002_G = new HashMap<>();
-        na002_G.put("GT", "0/1");
-        na002_G.put("AD", "3,8");
-        na002_G.put("DP", "15");
-        na002_G.put("GQ", "43");
-        na002_G.put("PL", "222,0,43");
-        Map<String, String> na003_G = new HashMap<>();
-        na003_G.put("GT", "0/0");
-        na003_G.put("AD", ".");
-        na003_G.put("DP", "18");
-        na003_G.put("GQ", ".");
-        na003_G.put("PL", ".");
-        Map<String, String> na004_G = new HashMap<>();
-        na004_G.put("GT", "2/1");
-        na004_G.put("AD", "7,6");
-        na004_G.put("DP", "13");
-        na004_G.put("GQ", "99");
-        na004_G.put("PL", "162,0,180");
-        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na001_G);
-        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na002_G);
-        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na003_G);
-        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na004_G);
-
-
-        // Check proper conversion of samples and alternate alleles
-        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
-        assertEquals(2, result.size());
-
-        Variant getVar0 = result.get(0);
-        assertEquals(
-                var0.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData(),
-                getVar0.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData());
-        assertArrayEquals(new String[]{"G"}, getVar0.getSourceEntry(FILE_ID, STUDY_ID).getSecondaryAlternates());
-
-        Variant getVar1 = result.get(1);
-        assertEquals(
-                var1.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData(),
-                getVar1.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData());
-        assertArrayEquals(new String[]{"C"}, getVar1.getSourceEntry(FILE_ID, STUDY_ID).getSecondaryAlternates());
-    }
-
-    @Test
-    public void testCreateVariantFromVcfCoLocatedVariants_Samples() {
-        String line = "1\t10040\trs123\tT\tC,GC\t.\t.\t.\tGT\t0/0\t0/1\t0/2\t1/1\t1/2\t2/2"; // 6 samples
-
-        // Initialize expected variants
-        Variant var0 = new Variant("1", 10041, 10041 + "C".length() - 1, "T", "C");
-        VariantSourceEntry file0 = new VariantSourceEntry(FILE_ID, STUDY_ID);
-        var0.addSourceEntry(file0);
-
-        Variant var1 = new Variant("1", 10050, 10050 + "GC".length() - 1, "T", "GC");
-        VariantSourceEntry file1 = new VariantSourceEntry(FILE_ID, STUDY_ID);
-        var1.addSourceEntry(file1);
-
-        // Initialize expected samples in variant 1 (alt allele C)
-        Map<String, String> na001_C = new HashMap<>();
-        na001_C.put("GT", "0/0");
-        Map<String, String> na002_C = new HashMap<>();
-        na002_C.put("GT", "0/1");
-        Map<String, String> na003_C = new HashMap<>();
-        na003_C.put("GT", "0/2");
-        Map<String, String> na004_C = new HashMap<>();
-        na004_C.put("GT", "1/1");
-        Map<String, String> na005_C = new HashMap<>();
-        na005_C.put("GT", "1/2");
-        Map<String, String> na006_C = new HashMap<>();
-        na006_C.put("GT", "2/2");
-
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na001_C);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na002_C);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na003_C);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na004_C);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na005_C);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na006_C);
-
-        // Initialize expected samples in variant 2 (alt allele GC)
-        Map<String, String> na001_GC = new HashMap<>();
-        na001_GC.put("GT", "0/0");
-        Map<String, String> na002_GC = new HashMap<>();
-        na002_GC.put("GT", "0/2");
-        Map<String, String> na003_GC = new HashMap<>();
-        na003_GC.put("GT", "0/1");
-        Map<String, String> na004_GC = new HashMap<>();
-        na004_GC.put("GT", "2/2");
-        Map<String, String> na005_GC = new HashMap<>();
-        na005_GC.put("GT", "2/1");
-        Map<String, String> na006_GC = new HashMap<>();
-        na006_GC.put("GT", "1/1");
-
-        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na001_GC);
-        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na002_GC);
-        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na003_GC);
-        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na004_GC);
-        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na005_GC);
-        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na006_GC);
-
-        // Check proper conversion of samples
-        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
-        assertEquals(2, result.size());
-
-        Variant getVar0 = result.get(0);
-        assertEquals(
-                var0.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData(),
-                getVar0.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData());
-        assertArrayEquals(new String[]{"GC"},
-                          getVar0.getSourceEntry(FILE_ID, STUDY_ID).getSecondaryAlternates());
-
-        Variant getVar1 = result.get(1);
-        assertEquals(
-                var1.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData(),
-                getVar1.getSourceEntry(FILE_ID, STUDY_ID).getSamplesData());
-        assertArrayEquals(new String[]{"C"},
-                          getVar1.getSourceEntry(FILE_ID, STUDY_ID).getSecondaryAlternates());
-    }
-
-    @Test
-    public void testCreateVariantWithMissingGenotypes() {
-        String line = "1\t1407616\t.\tC\tG\t43.74\tPASS\t.\tGT:AD:DP:GQ:PL\t./.:.:.:.:.\t1/1:0,2:2:6:71,6,0\t./.:.:.:.:.\t./.:.:.:.:.";
-
-        // Initialize expected variants
-        Variant var0 = new Variant("1", 1407616, 1407616, "C", "G");
-        VariantSourceEntry file0 = new VariantSourceEntry(FILE_ID, STUDY_ID);
-        var0.addSourceEntry(file0);
-
-        // Initialize expected samples
-        Map<String, String> na001 = new HashMap<>();
-        na001.put("GT", "./.");
-        na001.put("AD", ".");
-        na001.put("DP", ".");
-        na001.put("GQ", ".");
-        na001.put("PL", ".");
-        Map<String, String> na002 = new HashMap<>();
-        na002.put("GT", "1/1");
-        na002.put("AD", "0,2");
-        na002.put("DP", "2");
-        na002.put("GQ", "6");
-        na002.put("PL", "71,6,0");
-        Map<String, String> na003 = new HashMap<>();
-        na003.put("GT", "./.");
-        na003.put("AD", ".");
-        na003.put("DP", ".");
-        na003.put("GQ", ".");
-        na003.put("PL", ".");
-        Map<String, String> na004 = new HashMap<>();
-        na004.put("GT", "./.");
-        na004.put("AD", ".");
-        na004.put("DP", ".");
-        na004.put("GQ", ".");
-        na004.put("PL", ".");
-
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na001);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na002);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na003);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na004);
-
-
-        // Check proper conversion of samples
-        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
-        assertEquals(1, result.size());
-
-        Variant getVar0 = result.get(0);
-        VariantSourceEntry getFile0 = getVar0.getSourceEntry(FILE_ID, STUDY_ID);
-
-        Map<String, String> na001Data = getFile0.getSampleData(0);
-        assertEquals("./.", na001Data.get("GT"));
-        assertEquals(".", na001Data.get("AD"));
-        assertEquals(".", na001Data.get("DP"));
-        assertEquals(".", na001Data.get("GQ"));
-        assertEquals(".", na001Data.get("PL"));
-
-        Map<String, String> na002Data = getFile0.getSampleData(1);
-        assertEquals("1/1", na002Data.get("GT"));
-        assertEquals("0,2", na002Data.get("AD"));
-        assertEquals("2", na002Data.get("DP"));
-        assertEquals("6", na002Data.get("GQ"));
-        assertEquals("71,6,0", na002Data.get("PL"));
-
-        Map<String, String> na003Data = getFile0.getSampleData(2);
-        assertEquals("./.", na003Data.get("GT"));
-        assertEquals(".", na003Data.get("AD"));
-        assertEquals(".", na003Data.get("DP"));
-        assertEquals(".", na003Data.get("GQ"));
-        assertEquals(".", na003Data.get("PL"));
-
-        Map<String, String> na004Data = getFile0.getSampleData(3);
-        assertEquals("./.", na004Data.get("GT"));
-        assertEquals(".", na004Data.get("AD"));
-        assertEquals(".", na004Data.get("DP"));
-        assertEquals(".", na004Data.get("GQ"));
-        assertEquals(".", na004Data.get("PL"));
-    }
-
-    @Test
-    public void testParseInfo() {
-        String line = "1\t123456\t.\tT\tC,G\t110\tPASS\tAN=3;AC=1,2;AF=0.125,0.25;DP=63;NS=4;MQ=10685\tGT:AD:DP:GQ:PL\t"
-                + "0/1:10,5:17:94:94,0,286\t0/2:3,8:15:43:222,0,43\t0/0:.:18:.:.\t0/2:7,6:13:0:162,0,180"; // 4 samples
-
-        // Initialize expected variants
-        Variant var0 = new Variant("1", 123456, 123456, "T", "C");
-        VariantSourceEntry file0 = new VariantSourceEntry(FILE_ID, STUDY_ID);
-        var0.addSourceEntry(file0);
-
-        Variant var1 = new Variant("1", 123456, 123456, "T", "G");
-        VariantSourceEntry file1 = new VariantSourceEntry(FILE_ID, STUDY_ID);
-        var1.addSourceEntry(file1);
-
-
-        // Initialize expected samples
-        Map<String, String> na001 = new HashMap<>();
-        na001.put("GT", "0/1");
-        na001.put("AD", "10,5");
-        na001.put("DP", "17");
-        na001.put("GQ", "94");
-        na001.put("PL", "94,0,286");
-        Map<String, String> na002 = new HashMap<>();
-        na002.put("GT", "0/1");
-        na002.put("AD", "3,8");
-        na002.put("DP", "15");
-        na002.put("GQ", "43");
-        na002.put("PL", "222,0,43");
-        Map<String, String> na003 = new HashMap<>();
-        na003.put("GT", "0/0");
-        na003.put("AD", ".");
-        na003.put("DP", "18");
-        na003.put("GQ", ".");
-        na003.put("PL", ".");
-        Map<String, String> na004 = new HashMap<>();
-        na004.put("GT", "0/1");
-        na004.put("AD", "7,6");
-        na004.put("DP", "13");
-        na004.put("GQ", "0");
-        na004.put("PL", "162,0,180");
-
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na001);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na002);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na003);
-        var0.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na004);
-
-        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na001);
-        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na002);
-        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na003);
-        var1.getSourceEntry(FILE_ID, STUDY_ID).addSampleData(na004);
-
-
-        // Check proper conversion of samples
-        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
-        assertEquals(2, result.size());
-
-        Variant getVar0 = result.get(0);
-        VariantSourceEntry getFile0 = getVar0.getSourceEntry(FILE_ID, STUDY_ID);
-        assertEquals(4, Integer.parseInt(getFile0.getAttribute("NS")));
-//        assertEquals(2, Integer.parseInt(getFile0.getAttribute("AN")));
-        assertEquals(1, Integer.parseInt(getFile0.getAttribute("AC")));
-        assertEquals(0.125, Double.parseDouble(getFile0.getAttribute("AF")), 1e-8);
-        assertEquals(63, Integer.parseInt(getFile0.getAttribute("DP")));
-        assertEquals(10685, Integer.parseInt(getFile0.getAttribute("MQ")));
-        assertEquals(1, Integer.parseInt(getFile0.getAttribute("MQ0")));
-
-        Variant getVar1 = result.get(1);
-        VariantSourceEntry getFile1 = getVar1.getSourceEntry(FILE_ID, STUDY_ID);
-        assertEquals(4, Integer.parseInt(getFile1.getAttribute("NS")));
-//        assertEquals(2, Integer.parseInt(getFile1.getAttribute("AN")));
-        assertEquals(2, Integer.parseInt(getFile1.getAttribute("AC")));
-        assertEquals(0.25, Double.parseDouble(getFile1.getAttribute("AF")), 1e-8);
-        assertEquals(63, Integer.parseInt(getFile1.getAttribute("DP")));
-        assertEquals(10685, Integer.parseInt(getFile1.getAttribute("MQ")));
-        assertEquals(1, Integer.parseInt(getFile1.getAttribute("MQ0")));
-    }
-
-    @Test
     public void testVariantIds() {
 
         Set<String> emptySet = new HashSet<>();
         // test that an ID is properly handled
-        String line = "1\t1000\trs123\tC\tT\t.\t.\t.\tGT\t0/1";
+        String line = "1\t1000\trs123\tC\tT\t.\t.\t.";
         List<Variant> expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "C", "T"));
         List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
@@ -568,7 +226,7 @@ public class VariantVcfFactoryTest {
         assertEquals(emptySet, result.get(0).getIds());
 
         // test that the ';' is used as the ID separator (as of VCF 4.2)
-        line = "1\t1000\trs123;rs456\tC\tT\t.\t.\t.\tGT\t0/1";
+        line = "1\t1000\trs123;rs456\tC\tT\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "C", "T"));
         result = factory.create(FILE_ID, STUDY_ID, line);
@@ -576,91 +234,11 @@ public class VariantVcfFactoryTest {
         assertEquals(emptySet, result.get(0).getIds());
 
         // test that a missing ID ('.') is not added to the IDs set
-        line = "1\t1000\t.\tC\tT\t.\t.\t.\tGT\t0/1";
+        line = "1\t1000\t.\tC\tT\t.\t.\t.";
         expResult = new LinkedList<>();
         expResult.add(new Variant("1", 1000, 1000, "C", "T"));
         result = factory.create(FILE_ID, STUDY_ID, line);
         assertEquals(expResult, result);
         assertEquals(emptySet, result.get(0).getIds());
-    }
-
-    @Test
-    public void testVariantWithNoSampleInformation() {
-        // a variant with frequency but no genotypes, will be valid for the VariantAggregatedVcfFactory, but not a
-        // variant for VariantVcfFactory, that expects to find genotypes
-        String line = "1\t1000\t.\tT\tG\t.\t.\tAF=0.5";
-
-        thrown.expect(NonVariantException.class);
-        factory.create(FILE_ID, STUDY_ID, line);
-    }
-
-    @Test
-    public void testMultiallelicVariantWitnNoSampleInformation() {
-        // a variant with frequency but no genotypes, will be valid for the VariantAggregatedVcfFactory, but not a
-        // variant for VariantVcfFactory, that expects to find genotypes
-        String line = "1\t1000\t.\tT\tG,C\t.\t.\tAF=0.5";
-
-        thrown.expect(NonVariantException.class);
-        factory.create(FILE_ID, STUDY_ID, line);
-    }
-
-    @Test
-    public void variantWithNoAltGenotypes() {
-        String line = "1\t10040\trs123\tT\tC\t.\t.\t.\tGT\t0/0\t0|0\t./.\t0|0\t./.";
-
-        thrown.expect(NonVariantException.class);
-        factory.create(FILE_ID, STUDY_ID, line);
-    }
-
-    @Test
-    public void haploidVariantWithNoAltGenotypes() {
-        String line = "Y\t10040\trs123\tT\tC\t.\t.\t.\tGT\t.\t0\t0\t.";
-
-        thrown.expect(NonVariantException.class);
-        factory.create(FILE_ID, STUDY_ID, line);
-    }
-
-    @Test
-    public void triploidVariantWithNoAltGenotypes() {
-        String line = "1\t10040\trs123\tT\tC\t.\t.\t.\tGT\t0/0/0\t0|0|0\t././.\t0|0|0\t././.";
-
-        thrown.expect(NonVariantException.class);
-        factory.create(FILE_ID, STUDY_ID, line);
-    }
-
-    @Test
-    public void variantWhereAllGenotypesAreMissingValues() {
-        String line = "1\t10040\trs123\tT\tC\t.\t.\t.\tGT\t./.\t./.\t./.\t./.\t./.";
-
-        thrown.expect(NonVariantException.class);
-        factory.create(FILE_ID, STUDY_ID, line);
-    }
-
-    @Test
-    public void variantWhereAllGenotypesAreReference() {
-        String line = "1\t10040\trs123\tT\tC\t.\t.\t.\tGT\t0/0\t0|0\t0/0\t0|0\t0/0";
-
-        thrown.expect(NonVariantException.class);
-        factory.create(FILE_ID, STUDY_ID, line);
-    }
-
-    @Test
-    public void multiallelicVariantAndOneAlleleHasNoGenotypes() {
-        String line = "Y\t10040\trs123\tT\tC,G,A\t.\t.\t.\tGT\t0/0\t0/2\t./.\t2/2\t0/3\t2/3";
-
-        thrown.expect(NonVariantException.class);
-        factory.create(FILE_ID, STUDY_ID, line);
-    }
-
-    @Test
-    public void infoAttributesWontBeValidated() {
-        List<Variant> expResult = new LinkedList<>();
-        expResult.add(new Variant("1", 1000, 1000, "T", "G"));
-        String line;
-
-        // the variant is valid if it has some alternate genotypes, even if AF, AC or AN are zero
-        line = "chr1\t1000\t.\tT\tG\t.\t.\tAF=0;AC=0;AN=0\tGT\t0/1";
-        List<Variant> result = factory.create(FILE_ID, STUDY_ID, line);
-        assertEquals(expResult, result);
     }
 }


### PR DESCRIPTION
This codes makes the same than #65, but following a "less intrusive" approach into the existing code. Instead of modifying some of the existing methods in different classes of the factories hierarchy, I'm adding some private methods that need just a single call in the parent class. 

The performance is probably worse that the #65 approach, but the code looks nicer and is easier to read. -> EDIT: after testing, there is no performance penalty in this approach