### PR TITLE
EVA-1204 Post-accessioning validation checks

### DIFF
--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/VariantCoreFields.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/VariantCoreFields.java
@@ -18,6 +18,8 @@ package uk.ac.ebi.eva.commons.core.models;
 
 import org.apache.commons.lang3.StringUtils;
 
+import uk.ac.ebi.eva.commons.core.models.factories.exception.NonVariantException;
+
 import static java.lang.Math.max;
 
 /**
@@ -43,7 +45,7 @@ public class VariantCoreFields {
 
     public VariantCoreFields(String chromosome, long position, String reference, String alternate) {
         if (reference.equals(alternate)) {
-            throw new IllegalArgumentException("One alternate allele is identical to the reference. Variant found as: "
+            throw new NonVariantException("One alternate allele is identical to the reference. Variant found as: "
                                                        + chromosome + ":" + position + ":" + reference + ">" + alternate);
         }
 

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
@@ -63,7 +63,7 @@ public abstract class VariantVcfFactory {
         }
 
         String chromosome = getChromosomeWithoutPrefix(fields);
-        int position = getPosition(fields);
+        long position = getPosition(fields);
         String reference = getReference(fields);
         String[] alternateAlleles = getAlternateAlleles(fields);
 
@@ -101,7 +101,7 @@ public abstract class VariantVcfFactory {
      * Replace "chr" references only at the beginning of the chromosome name.
      * For instance, tomato has SL2.40ch00 and that should be kept that way
      */
-    private String getChromosomeWithoutPrefix(String[] fields) {
+    protected String getChromosomeWithoutPrefix(String[] fields) {
         String chromosome = fields[0];
         boolean ignoreCase = true;
         int startOffset = 0;
@@ -112,35 +112,35 @@ public abstract class VariantVcfFactory {
         return chromosome;
     }
 
-    private int getPosition(String[] fields) {
-        return Integer.parseInt(fields[1]);
+    protected long getPosition(String[] fields) {
+        return Long.parseLong(fields[1]);
     }
 
-    private String getReference(String[] fields) {
+    protected String getReference(String[] fields) {
         return fields[3].equals(".") ? "" : fields[3];
     }
 
-    private String[] getAlternateAlleles(String[] fields) {
+    protected String[] getAlternateAlleles(String[] fields) {
         return fields[4].split(",");
     }
 
-    private float getQuality(String[] fields) {
+    protected float getQuality(String[] fields) {
         return fields[5].equals(".") ? -1 : Float.parseFloat(fields[5]);
     }
 
-    private String getFilter(String[] fields) {
+    protected String getFilter(String[] fields) {
         return fields[6].equals(".") ? "" : fields[6];
     }
 
-    private String getInfo(String[] fields) {
+    protected String getInfo(String[] fields) {
         return fields[7].equals(".") ? "" : fields[7];
     }
 
-    private String getFormat(String[] fields) {
+    protected String getFormat(String[] fields) {
         return (fields.length <= 8 || fields[8].equals(".")) ? "" : fields[8];
     }
 
-    private List<VariantCoreFields> buildVariantCoreFields(String chromosome, int position, String reference,
+    private List<VariantCoreFields> buildVariantCoreFields(String chromosome, long position, String reference,
                                                            String[] alternateAlleles) {
         List<VariantCoreFields> generatedKeyFields = new ArrayList<>();
 

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/utils/FileUtils.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/utils/FileUtils.java
@@ -21,6 +21,7 @@ import org.springframework.core.io.Resource;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,6 +31,8 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipException;
 
 public class FileUtils {
+
+    private static final String GZIP_FILE_EXTENSION = ".gz";
 
     public static File getResourceFile(String resourcePath) {
         return new File(FileUtils.class.getResource(resourcePath).getFile());
@@ -55,6 +58,8 @@ public class FileUtils {
             inputStream.close();
         } catch (ZipException exception) {
             return false;
+        } catch (FileNotFoundException exception) {
+            return file.getName().endsWith(GZIP_FILE_EXTENSION);
         }
         return true;
     }


### PR DESCRIPTION
The next changes were handy for https://github.com/EBIvariation/eva-accession/pull/19

- use NonVariantException in VariantCoreFields
- use long for positions
- FileUtils.isGzip didn't work if the file didn't exist