### PR TITLE
EVA-1359 - Add new class to map variant types to their corresponding SO accessions.

### DIFF
--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/VariantType.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/VariantType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 EMBL - European Bioinformatics Institute
+ * Copyright 2018 EMBL - European Bioinformatics Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@ package uk.ac.ebi.eva.commons.core.models;
 
 /**
  * Type of variation, per Sequence Ontology (SO) definitions, which depends mostly on its length.
- * See <a href="https://docs.google.com/spreadsheets/d/1YH8qDBDu7C6tqULJNCrGw8uBjdW3ZT5OjTkJzGNOZ4E/edit#gid=1433496764">Sequence Ontology definitions</a>.
+ * See <a href="https://docs.google.com/spreadsheets/d/1YH8qDBDu7C6tqULJNCrGw8uBjdW3ZT5OjTkJzGNOZ4E/edit#gid=1433496764">Sequence Ontology definitions</a>,
+ * <a href="http://www.sequenceontology.org/browser/current_release/term/SO:0001537">Structural variant</a>
+ * and <a href="http://www.sequenceontology.org/browser/current_release/term/SO:0001019">Copy number variation</a>.
  */
 public enum VariantType {
 
@@ -59,11 +61,11 @@ public enum VariantType {
      */
     MNV,
     /**
-     * Structural variations are large changes of more than SV_THRESHOLD nucleotides
+     * SO:0001537 - Structural variations are large changes of more than SV_THRESHOLD nucleotides
      */
     SV,
     /**
-     * Copy-number variations alter the number of copies of a region
+     * SO:0001019 - Copy-number variations alter the number of copies of a region
      */
     CNV
 }

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/VariantTypeToSOAccessionMap.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/VariantTypeToSOAccessionMap.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.commons.core.models;
+
+import java.util.EnumMap;
+import java.util.stream.Collectors;
+
+/**
+ * Map variant types to their corresponding SO accessions
+ * See <a href="https://docs.google.com/spreadsheets/d/1YH8qDBDu7C6tqULJNCrGw8uBjdW3ZT5OjTkJzGNOZ4E/edit#gid=1433496764">Sequence Ontology definitions</a>,
+ * <a href="http://www.sequenceontology.org/browser/current_release/term/SO:0001537">Structural variant</a>
+ * and <a href="http://www.sequenceontology.org/browser/current_release/term/SO:0001019">Copy number variation</a>.
+ */
+public class VariantTypeToSOAccessionMap {
+
+    private static final EnumMap<VariantType, String> variantTypeToSOAccessionMap = new EnumMap<>(VariantType.class);
+
+    static String INVALID_VARIANT_TYPE_EXCEPTION_MESSAGE = "Invalid Variant Type '%s'. Only the following " +
+            "variant types have a valid SO accession: ";
+
+    static {
+        variantTypeToSOAccessionMap.put(VariantType.SNV, "SO:0001483");
+        variantTypeToSOAccessionMap.put(VariantType.DEL, "SO:0000159");
+        variantTypeToSOAccessionMap.put(VariantType.INS, "SO:0000667");
+        variantTypeToSOAccessionMap.put(VariantType.INDEL, "SO:1000032");
+        variantTypeToSOAccessionMap.put(VariantType.TANDEM_REPEAT, "SO:0000705");
+        variantTypeToSOAccessionMap.put(VariantType.SEQUENCE_ALTERATION, "SO:0001059");
+        variantTypeToSOAccessionMap.put(VariantType.NO_SEQUENCE_ALTERATION, "SO:0002073");
+        variantTypeToSOAccessionMap.put(VariantType.MNV, "SO:0002007");
+        variantTypeToSOAccessionMap.put(VariantType.SV, "SO:0001537");
+        variantTypeToSOAccessionMap.put(VariantType.CNV, "SO:0001019");
+
+        INVALID_VARIANT_TYPE_EXCEPTION_MESSAGE += variantTypeToSOAccessionMap.keySet().stream().map(Enum::toString)
+                                                                             .collect(Collectors.joining(","));
+    }
+
+    public static String getSequenceOntologyAccession(VariantType variantType) {
+        if (variantTypeToSOAccessionMap.containsKey(variantType)) {
+            return variantTypeToSOAccessionMap.get(variantType);
+        }
+
+        throw new IllegalArgumentException(String.format(INVALID_VARIANT_TYPE_EXCEPTION_MESSAGE, variantType));
+    }
+}

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/VariantTypeToSOAccessionMapTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/VariantTypeToSOAccessionMapTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.commons.core.models;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class VariantTypeToSOAccessionMapTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testInvalidVariantTypeLookup() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(
+                String.format(VariantTypeToSOAccessionMap.INVALID_VARIANT_TYPE_EXCEPTION_MESSAGE,
+                              VariantType.NO_ALTERNATE));
+        VariantTypeToSOAccessionMap.getSequenceOntologyAccession(VariantType.NO_ALTERNATE);
+    }
+
+    @Test
+    public void testValidVariantTypeLookup() {
+        assertEquals("SO:0001483", VariantTypeToSOAccessionMap.getSequenceOntologyAccession(VariantType.SNV));
+        assertEquals("SO:0000159", VariantTypeToSOAccessionMap.getSequenceOntologyAccession(VariantType.DEL));
+        assertEquals("SO:0000667", VariantTypeToSOAccessionMap.getSequenceOntologyAccession(VariantType.INS));
+        assertEquals("SO:1000032", VariantTypeToSOAccessionMap.getSequenceOntologyAccession(VariantType.INDEL));
+        assertEquals("SO:0000705", VariantTypeToSOAccessionMap.getSequenceOntologyAccession(VariantType.TANDEM_REPEAT));
+        assertEquals("SO:0001059",
+                     VariantTypeToSOAccessionMap.getSequenceOntologyAccession(VariantType.SEQUENCE_ALTERATION));
+        assertEquals("SO:0002073",
+                     VariantTypeToSOAccessionMap.getSequenceOntologyAccession(VariantType.NO_SEQUENCE_ALTERATION));
+        assertEquals("SO:0002007", VariantTypeToSOAccessionMap.getSequenceOntologyAccession(VariantType.MNV));
+        assertEquals("SO:0001537", VariantTypeToSOAccessionMap.getSequenceOntologyAccession(VariantType.SV));
+        assertEquals("SO:0001019", VariantTypeToSOAccessionMap.getSequenceOntologyAccession(VariantType.CNV));
+    }
+
+}


### PR DESCRIPTION
VariantTypeToSOAccessionMap.java, VariantTypeToSOAccessionMapTest.java  - Add new class to map variant types to their corresponding SO accessions.
VariantType.java - Updated SO terms for SV and CNV.