### PR TITLE
Update models for better use

### DIFF
--- a/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/entities/AnnotationMongo.java
+++ b/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/entities/AnnotationMongo.java
@@ -216,7 +216,7 @@ public class AnnotationMongo implements IAnnotation {
         consequenceTypes.forEach(this::addConsequenceType);
     }
 
-    private void addConsequenceType(ConsequenceTypeMongo consequenceType) {
+    public void addConsequenceType(ConsequenceTypeMongo consequenceType) {
         consequenceTypes.add(consequenceType);
         xrefs.addAll(generateXrefsFromConsequenceType(consequenceType));
     }

--- a/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/entities/VariantSourceMongo.java
+++ b/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/entities/VariantSourceMongo.java
@@ -55,6 +55,10 @@ public class VariantSourceMongo implements IVariantSource {
 
     public final static String METADATA_FIELD = "meta";
 
+    public final static String METADATA_FILEFORMAT_FIELD = "fileformat";
+
+    public final static String METADATA_HEADER_FIELD = "header";
+
     @Field(value = FILEID_FIELD)
     private String fileId;
 
@@ -84,6 +88,12 @@ public class VariantSourceMongo implements IVariantSource {
 
     @Field(value = STATISTICS_FIELD)
     private VariantGlobalStatsMongo stats;
+
+//    @Field(value = METADATA_FILEFORMAT_FIELD)
+//    private String MetadataFileformatField;
+
+//    @Field(value = METADATA_HEADER_FIELD)
+//    private String MetadataHeaderField;
 
     VariantSourceMongo() {
         //Empty spring constructor
@@ -183,4 +193,11 @@ public class VariantSourceMongo implements IVariantSource {
         this.stats = stats;
     }
 
+//    public String getMetadataFileformatField() {
+//        return MetadataFileformatField;
+//    }
+//
+//    public String getMetadataHeaderField() {
+//        return MetadataHeaderField;
+//    }
 }

--- a/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/entities/projections/SimplifiedVariant.java
+++ b/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/entities/projections/SimplifiedVariant.java
@@ -94,4 +94,39 @@ public class SimplifiedVariant {
         }
     }
 
+    public VariantType getVariantType() {
+        return variantType;
+    }
+
+    public String getChromosome() {
+        return chromosome;
+    }
+
+    public long getStart() {
+        return start;
+    }
+
+    public long getEnd() {
+        return end;
+    }
+
+    public int getLength() {
+        return length;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public String getAlternate() {
+        return alternate;
+    }
+
+    public VariantAtMongo getAt() {
+        return at;
+    }
+
+    public Set<HgvsMongo> getHgvs() {
+        return hgvs;
+    }
 }

--- a/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/writers/VariantMongoWriter.java
+++ b/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/writers/VariantMongoWriter.java
@@ -102,7 +102,7 @@ public class VariantMongoWriter extends MongoItemWriter<IVariant> {
     }
 
     @Override
-    protected void doWrite(List<? extends IVariant> variants) {
+    public void doWrite(List<? extends IVariant> variants) {
         BulkWriteOperation bulk = mongoOperations.getCollection(collection).initializeUnorderedBulkOperation();
         for (IVariant variant : variants) {
             bulk.find(generateQuery(variant)).upsert().updateOne(generateUpdate(variant));


### PR DESCRIPTION
These enhancements are found when I try to fix [issue #147](https://github.com/EBIvariation/eva-pipeline/issues/147) : Integrate ETL pipeline with auto-mapped variation-commons models

Changes are:

- Include getters for SimplifiedVariant.java
- Add 2 fields in VariantSourceMongo.java(for use in VariantSourceEntityMongo)
- Change VariantMongoWriter.dowrite and AnnotationMongo.addConsequenceType to public method