### PR TITLE
Update models wrt eva-pipeline issue #147

### DIFF
--- a/variation-commons-batch/src/main/java/uk/ac/ebi/eva/commons/batch/io/AggregatedVcfLineMapper.java
+++ b/variation-commons-batch/src/main/java/uk/ac/ebi/eva/commons/batch/io/AggregatedVcfLineMapper.java
@@ -73,7 +73,7 @@ public class AggregatedVcfLineMapper implements LineMapper<List<Variant>> {
             default:
                 throw new IllegalArgumentException(
                         this.getClass().getSimpleName() + " should be used to read aggregated VCFs only, " +
-                                "but the VariantSource.Aggregation is set to " + aggregation);
+                                "but the Aggregation is set to " + aggregation);
         }
     }
 

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/IVariantSource.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/IVariantSource.java
@@ -40,4 +40,5 @@ public interface IVariantSource {
 
     IVariantGlobalStats getStats();
 
+    void addMetadata(String key, Object value);
 }

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/VariantSource.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/VariantSource.java
@@ -18,6 +18,7 @@ package uk.ac.ebi.eva.commons.core.models;
 import uk.ac.ebi.eva.commons.core.models.stats.VariantGlobalStats;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -75,7 +76,7 @@ public class VariantSource implements IVariantSource {
         this.aggregation = aggregation;
         this.date = date;
         this.samplesPosition = samplesPosition;
-        this.metadata = metadata;
+        this.metadata = (metadata != null) ? metadata : new HashMap<>();
         if (stats != null) {
             this.stats = new VariantGlobalStats(stats);
         }
@@ -129,6 +130,11 @@ public class VariantSource implements IVariantSource {
     @Override
     public VariantGlobalStats getStats() {
         return stats;
+    }
+
+    @Override
+    public void addMetadata(String key, Object value) {
+        this.metadata.put(key, value);
     }
 
     @Override

--- a/variation-commons-mongodb/pom.xml
+++ b/variation-commons-mongodb/pom.xml
@@ -34,6 +34,13 @@
             <groupId>uk.ac.ebi.eva</groupId>
             <artifactId>variation-commons-core</artifactId>
             <version>0.7-SNAPSHOT</version>
+            <scope>system</scope>
+            <systemPath>${basedir}/src/test/resources/variation-commons-core-0.7-SNAPSHOT.jar</systemPath>
+        </dependency>
+        <dependency>
+            <groupId>uk.ac.ebi.eva</groupId>
+            <artifactId>biodata-models</artifactId>
+            <version>0.4.7</version>
         </dependency>
     </dependencies>
 

--- a/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/entities/VariantSourceMongo.java
+++ b/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/entities/VariantSourceMongo.java
@@ -183,4 +183,9 @@ public class VariantSourceMongo implements IVariantSource {
         this.stats = stats;
     }
 
+    @Override
+    public void addMetadata(String key, Object value) {
+        this.metadata.put(key, value);
+    }
+
 }

--- a/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/entities/projections/SimplifiedVariant.java
+++ b/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/entities/projections/SimplifiedVariant.java
@@ -94,4 +94,23 @@ public class SimplifiedVariant {
         }
     }
 
+    public String getChromosome() {
+        return chromosome;
+    }
+
+    public int getStart() {
+        return (int) start;
+    }
+
+    public int getEnd() {
+        return (int) end;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public String getAlternate() {
+        return alternate;
+    }
 }

--- a/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/entities/subdocuments/ConsequenceTypeMongo.java
+++ b/variation-commons-mongodb/src/main/java/uk/ac/ebi/eva/commons/mongodb/entities/subdocuments/ConsequenceTypeMongo.java
@@ -96,7 +96,7 @@ public class ConsequenceTypeMongo implements IConsequenceType {
     @Field(value = RELATIVE_POS_FIELD)
     private Integer relativePosition;
 
-    ConsequenceTypeMongo() {
+    public ConsequenceTypeMongo() {
         this(null, null, null, null, null, null, null, null, null, null, null, null, null, null);
     }
 

--- a/variation-commons-mongodb/src/test/resources/test-mongo.properties
+++ b/variation-commons-mongodb/src/test/resources/test-mongo.properties
@@ -1,5 +1,5 @@
 ## spring.data.mongodb.database
 spring.data.mongodb.host=localhost:27017
-#spring.data.mongodb.authentication-database
-#spring.data.mongodb.username
-#spring.data.mongodb.password
+spring.data.mongodb.authentication-database=admin
+spring.data.mongodb.username=appAdmin
+spring.data.mongodb.password=password


### PR DESCRIPTION
### Change
This is to enable integration of classes from commons with eva-pipline, specifically issue #147 : [Integrate ETL pipeline with auto-mapped variation-commons models](https://github.com/EBIvariation/eva-pipeline/issues/147)
- Make default constructor public for ConsequenceTypeMongo (this is needed for [AnnotationLineMapper.java](https://github.com/EBIvariation/eva-pipeline/blob/ad095cd43011645d06d84f758c4919ac04c4f04e/src/main/java/uk/ac/ebi/eva/pipeline/io/mappers/AnnotationLineMapper.java))
- Include missing 'addMetadata' method for `VariantSource.java` (for use in [VcfHeaderReader](https://github.com/EBIvariation/eva-pipeline/blob/ad095cd43011645d06d84f758c4919ac04c4f04e/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/VcfHeaderReader.java))
- Include getter for `SimplifiedVariant.java` (for use in [VariantsMongoReader](https://github.com/EBIvariation/eva-pipeline/blob/584498b29a17fb4738d80a773358a26778df0d97/src/main/java/uk/ac/ebi/eva/pipeline/io/readers/VariantsMongoReader.java))

#### How has this change been tested? 
`pass-build`