### PR TITLE
EVA-2043 use project and RS from the VCF

### DIFF
--- a/variation-commons-batch/src/main/java/uk/ac/ebi/eva/commons/batch/io/AggregatedVcfLineMapper.java
+++ b/variation-commons-batch/src/main/java/uk/ac/ebi/eva/commons/batch/io/AggregatedVcfLineMapper.java
@@ -86,7 +86,15 @@ public class AggregatedVcfLineMapper implements LineMapper<List<Variant>> {
         factory.setIncludeIds(includeIds);
     }
 
-    public boolean getIncludeIds() {
-        return factory.getIncludeIds();
+    public boolean isIncludeIds() {
+        return factory.isIncludeIds();
+    }
+
+    public void setRequireEvidence(boolean includeIds) {
+        factory.setRequireEvidence(includeIds);
+    }
+
+    public boolean isRequireEvidence() {
+        return factory.isRequireEvidence();
     }
 }

--- a/variation-commons-batch/src/main/java/uk/ac/ebi/eva/commons/batch/io/GenotypedVcfLineMapper.java
+++ b/variation-commons-batch/src/main/java/uk/ac/ebi/eva/commons/batch/io/GenotypedVcfLineMapper.java
@@ -51,7 +51,7 @@ public class GenotypedVcfLineMapper implements LineMapper<List<Variant>> {
         factory.setIncludeIds(includeIds);
     }
 
-    public boolean getIncludeIds() {
-        return factory.getIncludeIds();
+    public boolean isIncludeIds() {
+        return factory.isIncludeIds();
     }
 }

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -183,7 +183,7 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
      * @param variantStats
      */
     private void addStats(Variant variant, VariantSourceEntry sourceEntry, int numAllele, String[] alternateAlleles,
-                            Map<String, String> attributes, VariantStatistics variantStats) {
+                          Map<String, String> attributes, VariantStatistics variantStats) {
 
         if (attributes.containsKey(ALLELE_NUMBER) && attributes.containsKey(ALLELE_COUNT)) {
             int total = Integer.parseInt(attributes.get(ALLELE_NUMBER));
@@ -325,7 +325,7 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
         m = singleRef.matcher(gt);
         if (m.matches()) { // R
             g = new Genotype(variant.getReference() + "/" + variant.getReference(), variant.getReference(),
-                    variant.getAlternate());
+                             variant.getAlternate());
             return g;
         }
 
@@ -346,7 +346,7 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
         m = refRef.matcher(gt);
         if (m.matches()) { // RR
             g = new Genotype(variant.getReference() + "/" + variant.getReference(), variant.getReference(),
-                    variant.getAlternate());
+                             variant.getAlternate());
             return g;
         }
 
@@ -399,11 +399,13 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
             throws NonVariantException, IncompleteInformationException {
         super.checkVariantInformation(variant, fileId, studyId);
 
-        VariantSourceEntry variantSourceEntry = variant.getSourceEntry(fileId, studyId);
-        if (!canAlleleFrequenciesBeCalculated(variantSourceEntry)) {
-            throw new IncompleteInformationException(variant);
-        } else if (variantFrequencyIsZero(variantSourceEntry)) {
-            throw new NonVariantException("The variant " + variant + " has allele frequency or counts '0'");
+        if (requireEvidence) {
+            VariantSourceEntry variantSourceEntry = variant.getSourceEntry(fileId, studyId);
+            if (!canAlleleFrequenciesBeCalculated(variantSourceEntry)) {
+                throw new IncompleteInformationException(variant);
+            } else if (variantFrequencyIsZero(variantSourceEntry)) {
+                throw new NonVariantException("The variant " + variant + " has allele frequency or counts '0'");
+            }
         }
     }
 

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantGenotypedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantGenotypedVcfFactory.java
@@ -137,4 +137,16 @@ public class VariantGenotypedVcfFactory extends VariantVcfFactory {
         // updated those indexes so all calls to the alternate allele in this variant has now index 1
         return Arrays.stream(sampleField.split("[/|]")).anyMatch(allele -> allele.equals("1"));
     }
+
+    @Override
+    public void setRequireEvidence(boolean requireEvidence) {
+        if (requireEvidence) {
+            this.requireEvidence = requireEvidence;
+        } else {
+            throw new UnsupportedOperationException("There is no use case at the moment for "
+                                                            + this.getClass().getSimpleName()
+                                                            + " to not require evidence. This class expects all "
+                                                            + "variants to have frequencies or genotypes.");
+        }
+    }
 }

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantVcfFactory.java
@@ -46,6 +46,8 @@ public abstract class VariantVcfFactory {
 
     protected boolean includeIds = false;
 
+    protected boolean requireEvidence = true;
+
     /**
      * Creates a list of Variant objects using the fields in a record of a VCF
      * file. A new Variant object is created per allele, so several of them can
@@ -139,7 +141,7 @@ public abstract class VariantVcfFactory {
         this.includeIds = includeIds;
     }
 
-    public boolean getIncludeIds() {
+    public boolean isIncludeIds() {
         return includeIds;
     }
 
@@ -165,6 +167,14 @@ public abstract class VariantVcfFactory {
 
     protected String getFormat(String[] fields) {
         return (fields.length <= 8 || fields[8].equals(".")) ? "" : fields[8];
+    }
+
+    public boolean isRequireEvidence() {
+        return requireEvidence;
+    }
+
+    public void setRequireEvidence(boolean requireEvidence) {
+        this.requireEvidence = requireEvidence;
     }
 
     private List<VariantCoreFields> buildVariantCoreFields(String chromosome, long position, String reference,

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactoryTest.java
@@ -198,6 +198,18 @@ public class VariantAggregatedVcfFactoryTest {
     }
 
     @Test
+    public void allowVariantWithNoAlleleCountsOrFrequency() {
+        String line = "1\t1000\t.\tT\tG\t.\t.\tAA=A";
+
+        factory.setRequireEvidence(false);
+
+        List<Variant> variants = factory.create(FILE_ID, STUDY_ID, line);
+        assertEquals(1, variants.size());
+        assertEquals(1000, variants.get(0).getStart());
+        assertEquals("A", variants.get(0).getSourceEntries().iterator().next().getAttribute("AA"));
+    }
+
+    @Test
     public void testMultiallelicVariantWithNoAlleleCountsOrFrequency() {
         String line = "1\t1000\t.\tT\tG,A\t.\t.\tAA=A";
 

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantGenotypedVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantGenotypedVcfFactoryTest.java
@@ -410,6 +410,16 @@ public class VariantGenotypedVcfFactoryTest {
     }
 
     @Test
+    public void testRequireNoEvidence() {
+        // a variant with frequency but no genotypes, will be valid for the VariantAggregatedVcfFactory, but not for
+        // VariantGenotypedVcfFactory, that expects to find genotypes
+        String line = "1\t1000\t.\tT\tG\t.\t.\tAF=0.5";
+
+        thrown.expect(UnsupportedOperationException.class);
+        factory.setRequireEvidence(false);
+    }
+
+    @Test
     public void testMultiallelicVariantWitnNoSampleInformation() {
         // a variant with frequency but no genotypes, will be valid for the VariantAggregatedVcfFactory, but not for
         // VariantGenotypedVcfFactory, that expects to find genotypes


### PR DESCRIPTION
As the CoordinatesVcfFactory ignores the INFO column and we want to read it for EVA-2043, we have to use AggregatedVcfFactory and allow VCFs to not have evidence. Requiring evidence is still the default.