### PR TITLE
EVA-2412 - Add Spring Boot 1 job repository compatibility configuration

### DIFF
--- a/variation-commons-batch/pom.xml
+++ b/variation-commons-batch/pom.xml
@@ -26,5 +26,9 @@
             <artifactId>spring-batch-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/variation-commons-batch/src/main/java/uk/ac/ebi/eva/commons/batch/configuration/SpringBoot1CompatibilityConfiguration.java
+++ b/variation-commons-batch/src/main/java/uk/ac/ebi/eva/commons/batch/configuration/SpringBoot1CompatibilityConfiguration.java
@@ -16,6 +16,11 @@ import javax.sql.DataSource;
 
 public class SpringBoot1CompatibilityConfiguration {
 
+    // Due to the bug here: https://github.com/spring-projects/spring-batch/issues/1289#issue-538711146
+    // BatchConfigurer seems to override the transaction manager that is already present in the ExecutionContext
+    // This leads to issues like https://github.com/spring-projects/spring-batch/issues/961#issue-538704176
+    // Therefore, we have to "re-assert" to Spring Boot that we intend to use
+    // a JPA Transaction manager by putting back in the ExecutionContext
     private static JpaTransactionManager getTransactionManager(DataSource dataSource, EntityManagerFactory entityManagerFactory) {
         final JpaTransactionManager jpaTransactionManager = new JpaTransactionManager();
         jpaTransactionManager.setDataSource(dataSource);

--- a/variation-commons-batch/src/main/java/uk/ac/ebi/eva/commons/batch/configuration/SpringBoot1CompatibilityConfiguration.java
+++ b/variation-commons-batch/src/main/java/uk/ac/ebi/eva/commons/batch/configuration/SpringBoot1CompatibilityConfiguration.java
@@ -1,0 +1,60 @@
+package uk.ac.ebi.eva.commons.batch.configuration;
+
+import org.springframework.batch.core.configuration.annotation.BatchConfigurer;
+import org.springframework.batch.core.configuration.annotation.DefaultBatchConfigurer;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.explore.support.JobExplorerFactoryBean;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.support.JobRepositoryFactoryBean;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.vendor.HibernateJpaDialect;
+import org.springframework.transaction.PlatformTransactionManager;
+
+
+import javax.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+
+public class SpringBoot1CompatibilityConfiguration {
+
+    private static JpaTransactionManager getTransactionManager(DataSource dataSource, EntityManagerFactory entityManagerFactory) {
+        final JpaTransactionManager jpaTransactionManager = new JpaTransactionManager();
+        jpaTransactionManager.setDataSource(dataSource);
+        jpaTransactionManager.setJpaDialect(new HibernateJpaDialect());
+        jpaTransactionManager.setEntityManagerFactory(entityManagerFactory);
+        return jpaTransactionManager;
+    }
+
+    public static BatchConfigurer getSpringBoot1CompatibleBatchConfigurer(DataSource dataSource,
+                                                                          EntityManagerFactory entityManagerFactory)
+            throws Exception {
+        final JpaTransactionManager transactionManager = getTransactionManager(dataSource, entityManagerFactory);
+        final SpringBoot1CompatibleSerializer serializer = new SpringBoot1CompatibleSerializer();
+        return new DefaultBatchConfigurer(dataSource) {
+
+            @Override
+            protected JobRepository createJobRepository() throws Exception {
+
+                JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
+                factory.setDataSource(dataSource);
+                factory.setTransactionManager(transactionManager);
+                factory.setSerializer(serializer);
+                factory.afterPropertiesSet();
+                return factory.getObject();
+            }
+
+            @Override
+            protected JobExplorer createJobExplorer() throws Exception {
+                JobExplorerFactoryBean jobExplorerFactoryBean = new JobExplorerFactoryBean();
+                jobExplorerFactoryBean.setSerializer(serializer);
+                jobExplorerFactoryBean.setDataSource(dataSource);
+                jobExplorerFactoryBean.afterPropertiesSet();
+                return jobExplorerFactoryBean.getObject();
+            }
+
+            @Override
+            public PlatformTransactionManager getTransactionManager() {
+                return transactionManager;
+            }
+        };
+    }
+}

--- a/variation-commons-batch/src/main/java/uk/ac/ebi/eva/commons/batch/configuration/SpringBoot1CompatibleSerializer.java
+++ b/variation-commons-batch/src/main/java/uk/ac/ebi/eva/commons/batch/configuration/SpringBoot1CompatibleSerializer.java
@@ -1,0 +1,53 @@
+package uk.ac.ebi.eva.commons.batch.configuration;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springframework.batch.core.repository.ExecutionContextSerializer;
+import org.springframework.batch.core.repository.dao.Jackson2ExecutionContextStringSerializer;
+import org.springframework.batch.core.repository.dao.XStreamExecutionContextStringSerializer;
+
+
+/**
+ * ExecutionContext serialization/deserialization from Job repository changed in mechanism
+ * from XStream to Jackson in Spring Boot 2 (which includes the Spring Batch 4 library)
+ * - see https://docs.spring.io/spring-batch/docs/4.0.4.RELEASE/reference/html/whatsnew.html#whatsNewSerialization
+ *
+ * This class enables reading ExecutionContext entries written by Spring Boot 1.5 (Spring Batch 3)
+ * as well as Spring Boot 2.1 (Spring Batch 4) and write entries in Spring Boot 2 (Spring Batch 4) format
+ *
+ * Adapted from https://stackoverflow.com/a/55375553
+ */
+public class SpringBoot1CompatibleSerializer implements ExecutionContextSerializer {
+    private final XStreamExecutionContextStringSerializer xStream = new XStreamExecutionContextStringSerializer();
+    private final Jackson2ExecutionContextStringSerializer jackson = new Jackson2ExecutionContextStringSerializer();
+
+    public SpringBoot1CompatibleSerializer() throws Exception {
+        xStream.afterPropertiesSet();
+    }
+
+    @Override
+    public Map<String, Object> deserialize(InputStream inputStream) throws IOException {
+        InputStream repeatableInputStream = ensureMarkSupported(inputStream);
+        repeatableInputStream.mark(Integer.MAX_VALUE);
+
+        try {
+            return jackson.deserialize(repeatableInputStream);
+        } catch (JsonProcessingException e) {
+            repeatableInputStream.reset();
+            return xStream.deserialize(repeatableInputStream);
+        }
+    }
+
+    private static InputStream ensureMarkSupported(InputStream in) {
+        return in.markSupported() ? in : new BufferedInputStream(in);
+    }
+
+    @Override
+    public void serialize(Map<String, Object> object, OutputStream outputStream) throws IOException {
+        jackson.serialize(object, outputStream);
+    }
+}


### PR DESCRIPTION
Convenience classes for configuring Spring Boot 1 compatible batch environment. 

I have not added tests because of 2 reasons: 
* these classes are merely for configuration
* high overhead involved in testing (pulling in Spring Boot 1 + 2 libraries + simulating separate batch configuration environments)