### PR TITLE
EVA-4134 Allow AF to be missing (.)

### DIFF
--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -223,24 +223,28 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
         if (attributes.containsKey(ALLELE_FREQUENCY)) {
             String[] afs = attributes.get(ALLELE_FREQUENCY).split(",");
             if (afs.length == alternateAlleles.length) {
-                variantStats.setAltAlleleFreq(Float.parseFloat(afs[numAllele]));
-                if (variantStats.getMaf() == -1) {  // in case that we receive AFs but no ACs
-                    float sumFreq = 0;
-                    for (String af : afs) {
-                        sumFreq += Float.parseFloat(af);
-                    }
-                    float maf = 1 - sumFreq;
-                    String mafAllele = variantStats.getRefAllele();
-
-                    for (int i = 0; i < afs.length; i++) {
-                        float auxMaf = Float.parseFloat(afs[i]);
-                        if (auxMaf < maf) {
-                            maf = auxMaf;
-                            mafAllele = alternateAlleles[i];
+                try {
+                    variantStats.setAltAlleleFreq(Float.parseFloat(afs[numAllele]));
+                    if (variantStats.getMaf() == -1) {  // in case that we receive AFs but no ACs
+                        float sumFreq = 0;
+                        for (String af : afs) {
+                            sumFreq += Float.parseFloat(af);
                         }
+                        float maf = 1 - sumFreq;
+                        String mafAllele = variantStats.getRefAllele();
+
+                        for (int i = 0; i < afs.length; i++) {
+                            float auxMaf = Float.parseFloat(afs[i]);
+                            if (auxMaf < maf) {
+                                maf = auxMaf;
+                                mafAllele = alternateAlleles[i];
+                            }
+                        }
+                        variantStats.setMaf(maf);
+                        variantStats.setMafAllele(mafAllele);
                     }
-                    variantStats.setMaf(maf);
-                    variantStats.setMafAllele(mafAllele);
+                } catch (NumberFormatException ex) {
+                    logger.warn("ALLELE_FREQUENCY missing : AF values " + Arrays.toString(afs));
                 }
             }
         }
@@ -405,8 +409,8 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
             if (!canAlleleFrequenciesBeCalculated(variantSourceEntry)) {
                 throw new IncompleteInformationException(variant);
             } else if (variantFrequencyIsZero(variantSourceEntry)) {
-                logger.warn("The variant {} has allele frequency or counts '0' and will be discarded as a non-variant",
-                            variant);
+                logger.warn("The variant {} has allele frequency or counts '0'or '.' (missing) and will be discarded as a non-variant",
+                        variant);
                 return false;
             }
         }
@@ -431,7 +435,8 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
     }
 
     protected boolean isAttributeZeroInVariantSourceEntry(VariantSourceEntry variantSourceEntry, String attribute) {
-        return variantSourceEntry.hasAttribute(attribute) && variantSourceEntry.getAttribute(attribute).equals("0");
+        return variantSourceEntry.hasAttribute(attribute) &&
+                (variantSourceEntry.getAttribute(attribute).equals("0") || variantSourceEntry.getAttribute(attribute).equals("."));
     }
 
 }

--- a/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
+++ b/variation-commons-core/src/main/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactory.java
@@ -244,7 +244,7 @@ public class VariantAggregatedVcfFactory extends VariantVcfFactory {
                         variantStats.setMafAllele(mafAllele);
                     }
                 } catch (NumberFormatException ex) {
-                    logger.warn("ALLELE_FREQUENCY missing : AF values " + Arrays.toString(afs));
+                    logger.debug("ALLELE_FREQUENCY missing : AF values " + Arrays.toString(afs));
                 }
             }
         }

--- a/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactoryTest.java
+++ b/variation-commons-core/src/test/java/uk/ac/ebi/eva/commons/core/models/factories/VariantAggregatedVcfFactoryTest.java
@@ -31,6 +31,7 @@ import uk.ac.ebi.eva.commons.core.models.genotype.Genotype;
 import uk.ac.ebi.eva.commons.core.models.pipeline.Variant;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
@@ -159,6 +160,14 @@ public class VariantAggregatedVcfFactoryTest {
     }
 
     @Test
+    public void variantWithAlleleFrequencyMissing() {
+        String line = "1\t10040\trs123\tT\tC\t.\t.\tAF=.";
+
+        factory.create(FILE_ID, STUDY_ID, line);
+        assertNonVariantLogged();
+    }
+
+    @Test
     public void multiallelicWithAlleleFrequencyZero() {
         String line = "1\t10040\trs123\tT\tC,G,A\t.\t.\tAF=0.5,0,0.2";
 
@@ -240,7 +249,10 @@ public class VariantAggregatedVcfFactoryTest {
 
     private void assertNonVariantLogged() {
         List<ILoggingEvent> logsList = listAppender.list;
-        assertTrue(logsList.get(0).getMessage().contains("non-variant"));
-        assertEquals(Level.WARN, logsList.get(0).getLevel());
+        Optional<ILoggingEvent> nonVariantLogEvent = logsList.stream()
+                .filter(l -> l.getMessage().contains("will be discarded as a non-variant"))
+                .findAny();
+        assertTrue(nonVariantLogEvent.isPresent());
+        assertEquals(Level.WARN, nonVariantLogEvent.get().getLevel());
     }
 }


### PR DESCRIPTION
- eva-accession-pipeline :
       In the eva-accession-pipeline, we are using VCF readers from the variation-common library, so it will fail with the same error (NumberFormatException), if **AF=.** is provided.

- eva-pipeline (old)
   We had the same logic in the old Eva-pipeline also, which would have thrown the same error (NumberFormatException) when provided with **AF=.** in the file